### PR TITLE
[FLINK-25432][runtime] Introduces CheckpointResourcesCleanupRunner

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -214,11 +214,11 @@ public class ApplicationDispatcherBootstrapITCase {
         assertThat(
                         jobResultStore.hasDirtyJobResultEntry(
                                 ApplicationDispatcherBootstrap.ZERO_JOB_ID))
-                .isTrue();
+                .isFalse();
         assertThat(
                         jobResultStore.hasCleanJobResultEntry(
                                 ApplicationDispatcherBootstrap.ZERO_JOB_ID))
-                .isFalse();
+                .isTrue();
     }
 
     @Test

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -33,8 +33,8 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStore;
-import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.DefaultJobGraphStore;
@@ -323,7 +323,7 @@ public class KubernetesUtils {
                         k -> k.startsWith(CHECKPOINT_ID_KEY_PREFIX),
                         lockIdentity);
         Collection<CompletedCheckpoint> checkpoints =
-                DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                CompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                         stateHandleStore, KubernetesCheckpointStoreUtil.INSTANCE);
 
         return new DefaultCompletedCheckpointStore<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreUtils.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.persistence.ResourceVersion;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
@@ -37,13 +39,41 @@ import java.util.List;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Helper methods related to {@link DefaultCompletedCheckpointStore}. */
-public class DefaultCompletedCheckpointStoreUtils {
+public class CompletedCheckpointStoreUtils {
 
-    private static final Logger LOG =
-            LoggerFactory.getLogger(DefaultCompletedCheckpointStoreUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CompletedCheckpointStoreUtils.class);
 
-    private DefaultCompletedCheckpointStoreUtils() {
+    private CompletedCheckpointStoreUtils() {
         // No-op.
+    }
+
+    /**
+     * Extracts maximum number of retained checkpoints configuration from the passed {@link
+     * Configuration}. The default value is used as a fallback if the passed value is a value larger
+     * than {@code 0}.
+     *
+     * @param config The configuration that is accessed.
+     * @param logger The {@link Logger} used for exposing the warning if the configured value is
+     *     invalid.
+     * @return The maximum number of retained checkpoints based on the passed {@code Configuration}.
+     */
+    public static int getMaximumNumberOfRetainedCheckpoints(Configuration config, Logger logger) {
+        final int maxNumberOfCheckpointsToRetain =
+                config.getInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS);
+
+        if (maxNumberOfCheckpointsToRetain <= 0) {
+            // warning and use 1 as the default value if the setting in
+            // state.checkpoints.max-retained-checkpoints is not greater than 0.
+            logger.warn(
+                    "The setting for '{} : {}' is invalid. Using default value of {}",
+                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.key(),
+                    maxNumberOfCheckpointsToRetain,
+                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue());
+
+            return CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue();
+        }
+
+        return maxNumberOfCheckpointsToRetain;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
@@ -20,24 +20,37 @@ package org.apache.flink.runtime.clusterframework;
 
 import org.apache.flink.api.common.JobStatus;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.BiMap;
+import org.apache.flink.shaded.guava30.com.google.common.collect.EnumBiMap;
+
 /** The status of an application. */
 public enum ApplicationStatus {
 
-    /** Application finished successfully */
+    /** Application finished successfully. */
     SUCCEEDED(0),
 
-    /** Application encountered an unrecoverable failure or error */
+    /** Application encountered an unrecoverable failure or error. */
     FAILED(1443),
 
-    /** Application was canceled or killed on request */
+    /** Application was canceled or killed on request. */
     CANCELED(0),
 
-    /** Application status is not known */
+    /** Application status is not known. */
     UNKNOWN(1445);
 
     // ------------------------------------------------------------------------
 
-    /** The associated process exit code */
+    private static final BiMap<JobStatus, ApplicationStatus> JOB_STATUS_APPLICATION_STATUS_BI_MAP =
+            EnumBiMap.create(JobStatus.class, ApplicationStatus.class);
+
+    static {
+        // only globally-terminated JobStatus have a corresponding ApplicationStatus
+        JOB_STATUS_APPLICATION_STATUS_BI_MAP.put(JobStatus.FAILED, ApplicationStatus.FAILED);
+        JOB_STATUS_APPLICATION_STATUS_BI_MAP.put(JobStatus.CANCELED, ApplicationStatus.CANCELED);
+        JOB_STATUS_APPLICATION_STATUS_BI_MAP.put(JobStatus.FINISHED, ApplicationStatus.SUCCEEDED);
+    }
+
+    /** The associated process exit code. */
     private final int processExitCode;
 
     ApplicationStatus(int exitCode) {
@@ -45,7 +58,7 @@ public enum ApplicationStatus {
     }
 
     /**
-     * Gets the process exit code associated with this status
+     * Gets the process exit code associated with this status.
      *
      * @return The associated process exit code.
      */
@@ -59,20 +72,21 @@ public enum ApplicationStatus {
      * #UNKNOWN}.
      */
     public static ApplicationStatus fromJobStatus(JobStatus jobStatus) {
-        if (jobStatus == null) {
-            return UNKNOWN;
-        } else {
-            switch (jobStatus) {
-                case FAILED:
-                    return FAILED;
-                case CANCELED:
-                    return CANCELED;
-                case FINISHED:
-                    return SUCCEEDED;
+        return JOB_STATUS_APPLICATION_STATUS_BI_MAP.getOrDefault(jobStatus, UNKNOWN);
+    }
 
-                default:
-                    return UNKNOWN;
-            }
+    /**
+     * Derives the {@link JobStatus} from the {@code ApplicationStatus}.
+     *
+     * @return The corresponding {@code JobStatus}.
+     * @throws UnsupportedOperationException for {@link #UNKNOWN}.
+     */
+    public JobStatus deriveJobStatus() {
+        if (!JOB_STATUS_APPLICATION_STATUS_BI_MAP.inverse().containsKey(this)) {
+            throw new UnsupportedOperationException(
+                    this.name() + " cannot be mapped to a JobStatus.");
         }
+
+        return JOB_STATUS_APPLICATION_STATUS_BI_MAP.inverse().get(this);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -30,10 +30,12 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunner;
 import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleaner;
 import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
@@ -74,6 +76,7 @@ import org.apache.flink.runtime.rpc.PermanentlyFencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -130,6 +133,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     private final JobManagerRunnerRegistry jobManagerRunnerRegistry;
 
     private final Collection<JobGraph> recoveredJobs;
+
+    private final Collection<JobResult> recoveredDirtyJobs;
 
     private final DispatcherBootstrapFactory dispatcherBootstrapFactory;
 
@@ -276,6 +281,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
         this.recoveredJobs = new HashSet<>(recoveredJobs);
 
+        this.recoveredDirtyJobs = new HashSet<>(recoveredDirtyJobs);
+
         this.blobServer.retainJobs(
                 recoveredJobs.stream().map(JobGraph::getJobID).collect(Collectors.toSet()),
                 ioExecutor);
@@ -316,7 +323,9 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             throw exception;
         }
 
+        startCleanupRetries();
         startRecoveredJobs();
+
         this.dispatcherBootstrap =
                 this.dispatcherBootstrapFactory.create(
                         getSelfGateway(DispatcherGateway.class),
@@ -361,12 +370,32 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     private void runRecoveredJob(final JobGraph recoveredJob) {
         checkNotNull(recoveredJob);
         try {
-            runJob(recoveredJob, ExecutionType.RECOVERY);
+            initializeAndStartJobManagerRunner(recoveredJob, ExecutionType.RECOVERY);
         } catch (Throwable throwable) {
             onFatalError(
                     new DispatcherException(
                             String.format(
                                     "Could not start recovered job %s.", recoveredJob.getJobID()),
+                            throwable));
+        }
+    }
+
+    private void startCleanupRetries() {
+        recoveredDirtyJobs.forEach(this::runCleanupRetry);
+        recoveredDirtyJobs.clear();
+    }
+
+    private void runCleanupRetry(final JobResult jobResult) {
+        checkNotNull(jobResult);
+
+        try {
+            initializeAndStartCheckpointJobDataCleanupRunner(jobResult);
+        } catch (Throwable throwable) {
+            onFatalError(
+                    new DispatcherException(
+                            String.format(
+                                    "Could not start cleanup retry for job %s.",
+                                    jobResult.getJobId()),
                             throwable));
         }
     }
@@ -543,19 +572,30 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
     private void persistAndRunJob(JobGraph jobGraph) throws Exception {
         jobGraphWriter.putJobGraph(jobGraph);
-        runJob(jobGraph, ExecutionType.SUBMISSION);
+        initializeAndStartJobManagerRunner(jobGraph, ExecutionType.SUBMISSION);
     }
 
-    private void runJob(JobGraph jobGraph, ExecutionType executionType) throws Exception {
+    private void initializeAndStartJobManagerRunner(JobGraph jobGraph, ExecutionType executionType)
+            throws Exception {
         Preconditions.checkState(!jobManagerRunnerRegistry.isRegistered(jobGraph.getJobID()));
-        long initializationTimestamp = System.currentTimeMillis();
-        JobManagerRunner jobManagerRunner =
-                initializeJobManagerRunner(jobGraph, initializationTimestamp);
+        final JobManagerRunner jobManagerRunner = initializeJobManagerRunner(jobGraph);
+        runJob(jobManagerRunner, executionType);
+    }
 
+    private void initializeAndStartCheckpointJobDataCleanupRunner(JobResult jobResult)
+            throws Exception {
+        Preconditions.checkState(!jobManagerRunnerRegistry.isRegistered(jobResult.getJobId()));
+        final JobManagerRunner checkpointJobDataCleanupRunner =
+                initializeCheckpointJobDataCleanupRunner(jobResult);
+        runJob(checkpointJobDataCleanupRunner, ExecutionType.RECOVERY);
+    }
+
+    private void runJob(JobManagerRunner jobManagerRunner, ExecutionType executionType)
+            throws Exception {
         jobManagerRunner.start();
         jobManagerRunnerRegistry.register(jobManagerRunner);
 
-        final JobID jobId = jobGraph.getJobID();
+        final JobID jobId = jobManagerRunner.getJobID();
 
         final CompletableFuture<CleanupJobState> cleanupJobStateFuture =
                 jobManagerRunner
@@ -608,8 +648,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         return CleanupJobState.LOCAL;
     }
 
-    JobManagerRunner initializeJobManagerRunner(JobGraph jobGraph, long initializationTimestamp)
-            throws Exception {
+    private JobManagerRunner initializeJobManagerRunner(JobGraph jobGraph) throws Exception {
         final RpcService rpcService = getRpcService();
 
         return jobManagerRunnerFactory.createJobManagerRunner(
@@ -621,7 +660,19 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
                 jobManagerSharedServices,
                 new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup),
                 fatalErrorHandler,
-                initializationTimestamp);
+                System.currentTimeMillis());
+    }
+
+    private JobManagerRunner initializeCheckpointJobDataCleanupRunner(JobResult jobResult)
+            throws Exception {
+        return new CheckpointResourcesCleanupRunner(
+                jobResult,
+                highAvailabilityServices.getCheckpointRecoveryFactory(),
+                new CheckpointsCleaner(),
+                SharedStateRegistry.DEFAULT_FACTORY,
+                configuration,
+                ioExecutor,
+                System.currentTimeMillis());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -191,7 +191,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
                         configuration, blobServer, fatalErrorHandler);
 
         jobManagerRunnerRegistry =
-                new DefaultJobManagerRunnerRegistry(16, this.getMainThreadExecutor());
+                new OnMainThreadJobManagerRunnerRegistry(
+                        new DefaultJobManagerRunnerRegistry(16), this.getMainThreadExecutor());
 
         this.historyServerArchivist = dispatcherServices.getHistoryServerArchivist();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.dispatcher;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -169,36 +170,103 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             DispatcherServices dispatcherServices)
             throws Exception {
+        this(
+                rpcService,
+                fencingToken,
+                recoveredJobs,
+                recoveredDirtyJobs,
+                dispatcherBootstrapFactory,
+                dispatcherServices,
+                new DefaultJobManagerRunnerRegistry(16));
+    }
+
+    private Dispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            DispatcherServices dispatcherServices,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry)
+            throws Exception {
+        this(
+                rpcService,
+                fencingToken,
+                recoveredJobs,
+                globallyTerminatedJobs,
+                dispatcherServices.getConfiguration(),
+                dispatcherServices.getHighAvailabilityServices(),
+                dispatcherServices.getResourceManagerGatewayRetriever(),
+                dispatcherServices.getHeartbeatServices(),
+                dispatcherServices.getBlobServer(),
+                dispatcherServices.getFatalErrorHandler(),
+                dispatcherServices.getJobGraphWriter(),
+                dispatcherServices.getJobResultStore(),
+                dispatcherServices.getJobManagerMetricGroup(),
+                dispatcherServices.getMetricQueryServiceAddress(),
+                dispatcherServices.getIoExecutor(),
+                dispatcherServices.getHistoryServerArchivist(),
+                dispatcherServices.getArchivedExecutionGraphStore(),
+                dispatcherServices.getJobManagerRunnerFactory(),
+                dispatcherBootstrapFactory,
+                dispatcherServices.getOperationCaches(),
+                jobManagerRunnerRegistry,
+                new DispatcherResourceCleanerFactory(jobManagerRunnerRegistry, dispatcherServices));
+    }
+
+    @VisibleForTesting
+    protected Dispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> recoveredDirtyJobs,
+            Configuration configuration,
+            HighAvailabilityServices highAvailabilityServices,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            HeartbeatServices heartbeatServices,
+            BlobServer blobServer,
+            FatalErrorHandler fatalErrorHandler,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore,
+            JobManagerMetricGroup jobManagerMetricGroup,
+            @Nullable String metricServiceQueryAddress,
+            Executor ioExecutor,
+            HistoryServerArchivist historyServerArchivist,
+            ExecutionGraphInfoStore executionGraphInfoStore,
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            DispatcherOperationCaches dispatcherOperationCaches,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            ResourceCleanerFactory resourceCleanerFactory)
+            throws Exception {
         super(rpcService, RpcServiceUtils.createRandomName(DISPATCHER_NAME), fencingToken);
-        checkNotNull(dispatcherServices);
         assertRecoveredJobsAndDirtyJobResults(recoveredJobs, recoveredDirtyJobs);
 
-        this.configuration = dispatcherServices.getConfiguration();
-        this.highAvailabilityServices = dispatcherServices.getHighAvailabilityServices();
-        this.resourceManagerGatewayRetriever =
-                dispatcherServices.getResourceManagerGatewayRetriever();
-        this.heartbeatServices = dispatcherServices.getHeartbeatServices();
-        this.blobServer = dispatcherServices.getBlobServer();
-        this.fatalErrorHandler = dispatcherServices.getFatalErrorHandler();
-        this.jobGraphWriter = dispatcherServices.getJobGraphWriter();
-        this.jobResultStore = dispatcherServices.getJobResultStore();
-        this.jobManagerMetricGroup = dispatcherServices.getJobManagerMetricGroup();
-        this.metricServiceQueryAddress = dispatcherServices.getMetricQueryServiceAddress();
-        this.ioExecutor = dispatcherServices.getIoExecutor();
+        this.configuration = configuration;
+        this.highAvailabilityServices = highAvailabilityServices;
+        this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
+        this.heartbeatServices = heartbeatServices;
+        this.blobServer = blobServer;
+        this.fatalErrorHandler = fatalErrorHandler;
+        this.jobGraphWriter = jobGraphWriter;
+        this.jobResultStore = jobResultStore;
+        this.jobManagerMetricGroup = jobManagerMetricGroup;
+        this.metricServiceQueryAddress = metricServiceQueryAddress;
+        this.ioExecutor = ioExecutor;
 
         this.jobManagerSharedServices =
                 JobManagerSharedServices.fromConfiguration(
                         configuration, blobServer, fatalErrorHandler);
 
-        jobManagerRunnerRegistry =
+        this.jobManagerRunnerRegistry =
                 new OnMainThreadJobManagerRunnerRegistry(
-                        new DefaultJobManagerRunnerRegistry(16), this.getMainThreadExecutor());
+                        jobManagerRunnerRegistry, this.getMainThreadExecutor());
 
-        this.historyServerArchivist = dispatcherServices.getHistoryServerArchivist();
+        this.historyServerArchivist = historyServerArchivist;
 
-        this.executionGraphInfoStore = dispatcherServices.getArchivedExecutionGraphStore();
+        this.executionGraphInfoStore = executionGraphInfoStore;
 
-        this.jobManagerRunnerFactory = dispatcherServices.getJobManagerRunnerFactory();
+        this.jobManagerRunnerFactory = jobManagerRunnerFactory;
 
         this.jobManagerRunnerTerminationFutures = new HashMap<>(2);
 
@@ -214,12 +282,10 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
         this.dispatcherCachedOperationsHandler =
                 new DispatcherCachedOperationsHandler(
-                        dispatcherServices.getOperationCaches(),
+                        dispatcherOperationCaches,
                         this::triggerSavepointAndGetLocation,
                         this::stopWithSavepointAndGetLocation);
 
-        final ResourceCleanerFactory resourceCleanerFactory =
-                new DispatcherResourceCleanerFactory(jobManagerRunnerRegistry, dispatcherServices);
         this.localResourceCleaner =
                 resourceCleanerFactory.createLocalResourceCleaner(this.getMainThreadExecutor());
         this.globalResourceCleaner =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -550,8 +550,9 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         Preconditions.checkState(!jobManagerRunnerRegistry.isRegistered(jobGraph.getJobID()));
         long initializationTimestamp = System.currentTimeMillis();
         JobManagerRunner jobManagerRunner =
-                createJobManagerRunner(jobGraph, initializationTimestamp);
+                initializeJobManagerRunner(jobGraph, initializationTimestamp);
 
+        jobManagerRunner.start();
         jobManagerRunnerRegistry.register(jobManagerRunner);
 
         final JobID jobId = jobGraph.getJobID();
@@ -607,23 +608,20 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         return CleanupJobState.LOCAL;
     }
 
-    JobManagerRunner createJobManagerRunner(JobGraph jobGraph, long initializationTimestamp)
+    JobManagerRunner initializeJobManagerRunner(JobGraph jobGraph, long initializationTimestamp)
             throws Exception {
         final RpcService rpcService = getRpcService();
 
-        JobManagerRunner runner =
-                jobManagerRunnerFactory.createJobManagerRunner(
-                        jobGraph,
-                        configuration,
-                        rpcService,
-                        highAvailabilityServices,
-                        heartbeatServices,
-                        jobManagerSharedServices,
-                        new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup),
-                        fatalErrorHandler,
-                        initializationTimestamp);
-        runner.start();
-        return runner;
+        return jobManagerRunnerFactory.createJobManagerRunner(
+                jobGraph,
+                configuration,
+                rpcService,
+                highAvailabilityServices,
+                heartbeatServices,
+                jobManagerSharedServices,
+                new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup),
+                fatalErrorHandler,
+                initializationTimestamp);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -447,7 +447,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     public CompletableFuture<Acknowledge> submitFailedJob(
             JobID jobId, String jobName, Throwable exception) {
         final ArchivedExecutionGraph archivedExecutionGraph =
-                ArchivedExecutionGraph.createFromInitializingJob(
+                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                         jobId,
                         jobName,
                         JobStatus.FAILED,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherServices.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.dispatcher.cleanup.CleanupRunnerFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.JobResultStore;
@@ -65,6 +66,8 @@ public class DispatcherServices {
 
     private final JobManagerRunnerFactory jobManagerRunnerFactory;
 
+    private final CleanupRunnerFactory cleanupRunnerFactory;
+
     private final Executor ioExecutor;
 
     DispatcherServices(
@@ -82,6 +85,7 @@ public class DispatcherServices {
             JobGraphWriter jobGraphWriter,
             JobResultStore jobResultStore,
             JobManagerRunnerFactory jobManagerRunnerFactory,
+            CleanupRunnerFactory cleanupRunnerFactory,
             Executor ioExecutor) {
         this.configuration = Preconditions.checkNotNull(configuration, "Configuration");
         this.highAvailabilityServices =
@@ -104,6 +108,8 @@ public class DispatcherServices {
         this.jobResultStore = Preconditions.checkNotNull(jobResultStore, "JobResultStore");
         this.jobManagerRunnerFactory =
                 Preconditions.checkNotNull(jobManagerRunnerFactory, "JobManagerRunnerFactory");
+        this.cleanupRunnerFactory =
+                Preconditions.checkNotNull(cleanupRunnerFactory, "CleanupRunnerFactory");
         this.ioExecutor = Preconditions.checkNotNull(ioExecutor, "IOExecutor");
     }
 
@@ -164,6 +170,10 @@ public class DispatcherServices {
         return jobManagerRunnerFactory;
     }
 
+    CleanupRunnerFactory getCleanupRunnerFactory() {
+        return cleanupRunnerFactory;
+    }
+
     public Executor getIoExecutor() {
         return ioExecutor;
     }
@@ -171,7 +181,8 @@ public class DispatcherServices {
     public static DispatcherServices from(
             PartialDispatcherServicesWithJobPersistenceComponents
                     partialDispatcherServicesWithJobPersistenceComponents,
-            JobManagerRunnerFactory jobManagerRunnerFactory) {
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            CleanupRunnerFactory cleanupRunnerFactory) {
         return new DispatcherServices(
                 partialDispatcherServicesWithJobPersistenceComponents.getConfiguration(),
                 partialDispatcherServicesWithJobPersistenceComponents.getHighAvailabilityServices(),
@@ -192,6 +203,7 @@ public class DispatcherServices {
                 partialDispatcherServicesWithJobPersistenceComponents.getJobGraphWriter(),
                 partialDispatcherServicesWithJobPersistenceComponents.getJobResultStore(),
                 jobManagerRunnerFactory,
+                cleanupRunnerFactory,
                 partialDispatcherServicesWithJobPersistenceComponents.getIoExecutor());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunnerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -64,7 +65,8 @@ public enum JobDispatcherFactory implements DispatcherFactory {
                 fencingToken,
                 DispatcherServices.from(
                         partialDispatcherServicesWithJobPersistenceComponents,
-                        JobMasterServiceLeadershipRunnerFactory.INSTANCE),
+                        JobMasterServiceLeadershipRunnerFactory.INSTANCE,
+                        CheckpointResourcesCleanupRunnerFactory.INSTANCE),
                 recoveredJobGraph,
                 recoveredDirtyJob,
                 dispatcherBootstrapFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code OnMainThreadJobManagerRunnerRegistry} implements {@link JobManagerRunnerRegistry} guarding
+ * the passed {@code JobManagerRunnerRegistry} instance in a way that it only allows modifying
+ * methods to be executed on the component's main thread.
+ *
+ * @see ComponentMainThreadExecutor
+ */
+public class OnMainThreadJobManagerRunnerRegistry implements JobManagerRunnerRegistry {
+
+    private final JobManagerRunnerRegistry delegate;
+    private final ComponentMainThreadExecutor mainThreadExecutor;
+
+    public OnMainThreadJobManagerRunnerRegistry(
+            JobManagerRunnerRegistry delegate, ComponentMainThreadExecutor mainThreadExecutor) {
+        this.delegate = delegate;
+        this.mainThreadExecutor = mainThreadExecutor;
+    }
+
+    @Override
+    public boolean isRegistered(JobID jobId) {
+        return delegate.isRegistered(jobId);
+    }
+
+    @Override
+    public void register(JobManagerRunner jobManagerRunner) {
+        mainThreadExecutor.assertRunningInMainThread();
+        delegate.register(jobManagerRunner);
+    }
+
+    @Override
+    public JobManagerRunner get(JobID jobId) {
+        return delegate.get(jobId);
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public Set<JobID> getRunningJobIds() {
+        return delegate.getRunningJobIds();
+    }
+
+    @Override
+    public Collection<JobManagerRunner> getJobManagerRunners() {
+        return delegate.getJobManagerRunners();
+    }
+
+    @Override
+    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.globalCleanupAsync(jobId, executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.localCleanupAsync(jobId, executor);
+    }
+
+    @Override
+    public JobManagerRunner unregister(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.unregister(jobId);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SessionDispatcherFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.dispatcher;
 
+import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunnerFactory;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -47,6 +48,7 @@ public enum SessionDispatcherFactory implements DispatcherFactory {
                 dispatcherBootstrapFactory,
                 DispatcherServices.from(
                         partialDispatcherServicesWithJobPersistenceComponents,
-                        JobMasterServiceLeadershipRunnerFactory.INSTANCE));
+                        JobMasterServiceLeadershipRunnerFactory.INSTANCE,
+                        CheckpointResourcesCleanupRunnerFactory.INSTANCE));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreUtils;
+import org.apache.flink.runtime.dispatcher.UnavailableDispatcherOperationException;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobManagerRunnerResult;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code CheckpointResourcesCleanupRunner} implements {@link JobManagerRunner} in a way, that only
+ * the checkpoint-related resources are instantiated. It triggers any job-specific cleanup that's
+ * usually performed by the {@link JobMaster} without rebuilding the corresponding {@link
+ * org.apache.flink.runtime.executiongraph.ExecutionGraph}.
+ */
+public class CheckpointResourcesCleanupRunner implements JobManagerRunner {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(CheckpointResourcesCleanupRunner.class);
+
+    private final JobResult jobResult;
+    private final CheckpointRecoveryFactory checkpointRecoveryFactory;
+    private final CheckpointsCleaner checkpointsCleaner;
+    private final SharedStateRegistryFactory sharedStateRegistryFactory;
+    private final Configuration jobManagerConfiguration;
+    private final Executor cleanupExecutor;
+
+    private final long initializationTimestamp;
+
+    // we have to have two separate futures because closeAsync relies on the completion of
+    // getResultFuture which is always already completed but the cleanupFuture is only
+    // instantiated when calling start
+    private CompletableFuture<Void> cleanupFuture;
+    private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    private CompletedCheckpointStore completedCheckpointStore;
+    private CheckpointIDCounter checkpointIDCounter;
+
+    public CheckpointResourcesCleanupRunner(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            CheckpointsCleaner checkpointsCleaner,
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            Configuration jobManagerConfiguration,
+            Executor cleanupExecutor,
+            long initializationTimestamp) {
+        this.jobResult = Preconditions.checkNotNull(jobResult);
+        this.checkpointRecoveryFactory = Preconditions.checkNotNull(checkpointRecoveryFactory);
+        this.checkpointsCleaner = Preconditions.checkNotNull(checkpointsCleaner);
+        this.sharedStateRegistryFactory = Preconditions.checkNotNull(sharedStateRegistryFactory);
+        this.jobManagerConfiguration = Preconditions.checkNotNull(jobManagerConfiguration);
+        this.cleanupExecutor = Preconditions.checkNotNull(cleanupExecutor);
+        this.initializationTimestamp = initializationTimestamp;
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        return closeFuture;
+    }
+
+    @Override
+    public void start() throws Exception {
+        cleanupFuture =
+                CompletableFuture.runAsync(this::initializeAccessingComponents, cleanupExecutor)
+                        .thenApply(
+                                result -> {
+                                    Exception exception = null;
+                                    try {
+                                        completedCheckpointStore.shutdown(
+                                                getJobStatus(), checkpointsCleaner);
+                                    } catch (Exception e) {
+                                        exception = e;
+                                    }
+
+                                    try {
+                                        checkpointIDCounter.shutdown(getJobStatus());
+                                    } catch (Exception e) {
+                                        exception = ExceptionUtils.firstOrSuppressed(e, exception);
+                                    }
+
+                                    if (exception != null) {
+                                        throw new CompletionException(exception);
+                                    }
+
+                                    return null;
+                                });
+
+        FutureUtils.forward(cleanupFuture, closeFuture);
+    }
+
+    private void initializeAccessingComponents() {
+        initializeCompletedCheckpointStore();
+        initializeCheckpointIDCounter();
+    }
+
+    private void initializeCompletedCheckpointStore() {
+        try {
+            this.completedCheckpointStore =
+                    checkpointRecoveryFactory.createRecoveredCompletedCheckpointStore(
+                            getJobID(),
+                            CompletedCheckpointStoreUtils.getMaximumNumberOfRetainedCheckpoints(
+                                    jobManagerConfiguration, LOG),
+                            sharedStateRegistryFactory,
+                            cleanupExecutor);
+        } catch (Exception e) {
+            throw new CompletionException(
+                    "Error occurred while initializing the CompletedCheckpointStore access.", e);
+        }
+    }
+
+    private void initializeCheckpointIDCounter() {
+        try {
+            this.checkpointIDCounter =
+                    checkpointRecoveryFactory.createCheckpointIDCounter(getJobID());
+        } catch (Exception e) {
+            throw new CompletionException(
+                    "Error occurred while initializing the CheckpointIDCounter access.", e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<JobMasterGateway> getJobMasterGateway() {
+        return FutureUtils.completedExceptionally(
+                new UnavailableDispatcherOperationException(
+                        "Unable to get JobMasterGateway for job in cleanup phase. The requested operation is not available in that stage."));
+    }
+
+    @Override
+    public CompletableFuture<JobManagerRunnerResult> getResultFuture() {
+        return CompletableFuture.completedFuture(
+                JobManagerRunnerResult.forSuccess(createExecutionGraphInfoFromJobResult()));
+    }
+
+    @Override
+    public JobID getJobID() {
+        return jobResult.getJobId();
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> cancel(Time timeout) {
+        Preconditions.checkState(
+                cleanupFuture != null,
+                "The CheckpointResourcesCleanupRunner was not started, yet.");
+        if (cleanupFuture.cancel(true)) {
+            return CompletableFuture.completedFuture(Acknowledge.get());
+        }
+
+        return FutureUtils.completedExceptionally(
+                new FlinkException("Cleanup task couldn't be cancelled."));
+    }
+
+    @Override
+    public CompletableFuture<JobStatus> requestJobStatus(Time timeout) {
+        return CompletableFuture.completedFuture(getJobStatus());
+    }
+
+    @Override
+    public CompletableFuture<JobDetails> requestJobDetails(Time timeout) {
+        return requestJob(timeout)
+                .thenApply(
+                        executionGraphInfo ->
+                                JobDetails.createDetailsForJob(
+                                        executionGraphInfo.getArchivedExecutionGraph()));
+    }
+
+    @Override
+    public CompletableFuture<ExecutionGraphInfo> requestJob(Time timeout) {
+        return CompletableFuture.completedFuture(createExecutionGraphInfoFromJobResult());
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return true;
+    }
+
+    private ExecutionGraphInfo createExecutionGraphInfoFromJobResult() {
+        return generateExecutionGraphInfo(jobResult, initializationTimestamp);
+    }
+
+    private JobStatus getJobStatus() {
+        return getJobStatus(jobResult);
+    }
+
+    private static JobStatus getJobStatus(JobResult jobResult) {
+        return jobResult.getApplicationStatus().deriveJobStatus();
+    }
+
+    private static ExecutionGraphInfo generateExecutionGraphInfo(
+            JobResult jobResult, long initializationTimestamp) {
+        return new ExecutionGraphInfo(
+                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
+                        jobResult.getJobId(),
+                        "unknown",
+                        getJobStatus(jobResult),
+                        jobResult.getSerializedThrowable().orElse(null),
+                        null,
+                        initializationTimestamp));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code CheckpointResourcesCleanupRunnerFactory} implements {@link CleanupRunnerFactory} providing
+ * a factory method for creating {@link CheckpointResourcesCleanupRunner} instances.
+ */
+public enum CheckpointResourcesCleanupRunnerFactory implements CleanupRunnerFactory {
+    INSTANCE;
+
+    @Override
+    public CheckpointResourcesCleanupRunner create(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Configuration configuration,
+            Executor cleanupExecutor) {
+        return new CheckpointResourcesCleanupRunner(
+                jobResult,
+                checkpointRecoveryFactory,
+                new CheckpointsCleaner(),
+                SharedStateRegistry.DEFAULT_FACTORY,
+                configuration,
+                cleanupExecutor,
+                System.currentTimeMillis());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRunnerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobResult;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code CleanupRunnerFactory} provides a factory method for creating {@link
+ * CheckpointResourcesCleanupRunner} instances.
+ */
+@FunctionalInterface
+public interface CleanupRunnerFactory {
+    JobManagerRunner create(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Configuration configuration,
+            Executor cleanupExecutor);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
@@ -62,7 +62,7 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
     }
 
     @VisibleForTesting
-    DispatcherResourceCleanerFactory(
+    public DispatcherResourceCleanerFactory(
             Executor cleanupExecutor,
             JobManagerRunnerRegistry jobManagerRunnerRegistry,
             JobGraphWriter jobGraphWriter,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -334,7 +334,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
      * Create a sparse ArchivedExecutionGraph for a job while it is still initializing. Most fields
      * will be empty, only job status and error-related fields are set.
      */
-    public static ArchivedExecutionGraph createFromInitializingJob(
+    public static ArchivedExecutionGraph createSparseArchivedExecutionGraph(
             JobID jobId,
             String jobName,
             JobStatus jobStatus,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceProcessFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceProcessFactory.java
@@ -68,7 +68,7 @@ public class DefaultJobMasterServiceProcessFactory implements JobMasterServicePr
     @Override
     public ArchivedExecutionGraph createArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
-        return ArchivedExecutionGraph.createFromInitializingJob(
+        return ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                 jobId, jobName, jobStatus, cause, checkpointingSettings, initializationTimestamp);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
@@ -20,11 +20,11 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.checkpoint.DeactivatedCheckpointCompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.DeactivatedCheckpointIDCounter;
 import org.apache.flink.runtime.client.JobExecutionException;
@@ -75,25 +75,10 @@ public final class SchedulerUtils {
             Logger log,
             JobID jobId)
             throws Exception {
-        int maxNumberOfCheckpointsToRetain =
-                jobManagerConfig.getInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS);
-
-        if (maxNumberOfCheckpointsToRetain <= 0) {
-            // warning and use 1 as the default value if the setting in
-            // state.checkpoints.max-retained-checkpoints is not greater than 0.
-            log.warn(
-                    "The setting for '{} : {}' is invalid. Using default value of {}",
-                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.key(),
-                    maxNumberOfCheckpointsToRetain,
-                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue());
-
-            maxNumberOfCheckpointsToRetain =
-                    CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue();
-        }
-
         return recoveryFactory.createRecoveredCompletedCheckpointStore(
                 jobId,
-                maxNumberOfCheckpointsToRetain,
+                CompletedCheckpointStoreUtils.getMaximumNumberOfRetainedCheckpoints(
+                        jobManagerConfig, log),
                 SharedStateRegistry.DEFAULT_FACTORY,
                 ioExecutor);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -756,7 +756,7 @@ public class AdaptiveScheduler
     @Override
     public ArchivedExecutionGraph getArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
-        return ArchivedExecutionGraph.createFromInitializingJob(
+        return ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                 jobInformation.getJobID(),
                 jobInformation.getName(),
                 jobStatus,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -26,8 +26,8 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStore;
-import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.checkpoint.DefaultLastStateConnectionStateListener;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointStoreUtil;
@@ -589,7 +589,7 @@ public class ZooKeeperUtils {
         final ZooKeeperStateHandleStore<CompletedCheckpoint> completedCheckpointStateHandleStore =
                 createZooKeeperStateHandleStore(client, getCheckpointsPath(), stateStorage);
         Collection<CompletedCheckpoint> completedCheckpoints =
-                DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                CompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                         completedCheckpointStateHandleStore, ZooKeeperCheckpointStoreUtil.INSTANCE);
         final CompletedCheckpointStore zooKeeperCompletedCheckpointStore =
                 new DefaultCompletedCheckpointStore<>(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
@@ -143,7 +143,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
 
     /**
      * We have three completed checkpoints(1, 2, 3) in the state handle store. We expect that {@link
-     * DefaultCompletedCheckpointStoreUtils#retrieveCompletedCheckpoints(StateHandleStore,
+     * CompletedCheckpointStoreUtils#retrieveCompletedCheckpoints(StateHandleStore,
      * CheckpointStoreUtil)} should recover the sorted checkpoints by name.
      */
     @Test
@@ -394,7 +394,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
                 toRetain,
                 stateHandleStore,
                 checkpointStoreUtil,
-                DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                CompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                         stateHandleStore, checkpointStoreUtil),
                 SharedStateRegistry.DEFAULT_FACTORY.create(
                         org.apache.flink.util.concurrent.Executors.directExecutor(), emptyList()),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
@@ -56,7 +56,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerShutsDownCheckpointCoordinatorOnFailedExecutionGraph()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
         CompletedCheckpointStore store =
@@ -84,7 +86,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerShutsDownCheckpointCoordinatorOnSuspendedExecutionGraph()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
         CompletedCheckpointStore store =
@@ -112,7 +116,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerShutsDownCheckpointCoordinatorOnFinishedExecutionGraph()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
         CompletedCheckpointStore store =
@@ -149,7 +155,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
     public void testClosingSchedulerSuspendsExecutionGraphAndShutsDownCheckpointCoordinator()
             throws Exception {
         final CompletableFuture<JobStatus> counterShutdownFuture = new CompletableFuture<>();
-        CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
+        CheckpointIDCounter counter =
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
         CompletedCheckpointStore store =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
@@ -59,7 +59,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
         CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();
@@ -85,7 +87,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
         CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();
@@ -111,7 +115,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
         CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();
@@ -146,7 +152,9 @@ public class DefaultSchedulerCheckpointCoordinatorTest extends TestLogger {
         CheckpointIDCounter counter = new TestingCheckpointIDCounter(counterShutdownFuture);
 
         final CompletableFuture<JobStatus> storeShutdownFuture = new CompletableFuture<>();
-        CompletedCheckpointStore store = new TestingCompletedCheckpointStore(storeShutdownFuture);
+        CompletedCheckpointStore store =
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(storeShutdownFuture);
 
         final SchedulerBase scheduler = createSchedulerAndEnableCheckpointing(counter, store);
         final ExecutionGraph graph = scheduler.getExecutionGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
@@ -36,7 +36,9 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
     @Test
     public void testFactoryWithoutCheckpointStoreRecovery() throws Exception {
         final TestingCompletedCheckpointStore store =
-                new TestingCompletedCheckpointStore(new CompletableFuture<>());
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                new CompletableFuture<>());
         final CheckpointRecoveryFactory factory =
                 PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
                         maxCheckpoints -> store);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointIDCounter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointIDCounter.java
@@ -20,36 +20,109 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobStatus;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /** Test {@link CheckpointIDCounter} implementation for testing the shutdown behavior. */
 public final class TestingCheckpointIDCounter implements CheckpointIDCounter {
 
-    private final CompletableFuture<JobStatus> shutdownStatus;
+    private final Runnable startRunnable;
+    private final Consumer<JobStatus> shutdownConsumer;
+    private final Supplier<Integer> getAndIncrementSupplier;
+    private final Supplier<Integer> getSupplier;
+    private final Consumer<Long> setCountConsumer;
 
-    public TestingCheckpointIDCounter(CompletableFuture<JobStatus> shutdownStatus) {
-        this.shutdownStatus = shutdownStatus;
+    public static TestingCheckpointIDCounter createStoreWithShutdownCheckAndNoStartAction(
+            CompletableFuture<JobStatus> shutdownFuture) {
+        return TestingCheckpointIDCounter.builder()
+                .withStartRunnable(() -> {})
+                .withShutdownConsumer(shutdownFuture::complete)
+                .build();
+    }
+
+    private TestingCheckpointIDCounter(
+            Runnable startRunnable,
+            Consumer<JobStatus> shutdownConsumer,
+            Supplier<Integer> getAndIncrementSupplier,
+            Supplier<Integer> getSupplier,
+            Consumer<Long> setCountConsumer) {
+        this.startRunnable = startRunnable;
+        this.shutdownConsumer = shutdownConsumer;
+        this.getAndIncrementSupplier = getAndIncrementSupplier;
+        this.getSupplier = getSupplier;
+        this.setCountConsumer = setCountConsumer;
     }
 
     @Override
-    public void start() {}
+    public void start() {
+        startRunnable.run();
+    }
 
     @Override
     public void shutdown(JobStatus jobStatus) {
-        shutdownStatus.complete(jobStatus);
+        shutdownConsumer.accept(jobStatus);
     }
 
     @Override
     public long getAndIncrement() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getAndIncrementSupplier.get();
     }
 
     @Override
     public long get() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getSupplier.get();
     }
 
     @Override
     public void setCount(long newId) {
-        throw new UnsupportedOperationException("Not implemented.");
+        setCountConsumer.accept(newId);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingCheckpointIDCounter} instances. */
+    public static class Builder {
+
+        private Runnable startRunnable;
+        private Consumer<JobStatus> shutdownConsumer;
+        private Supplier<Integer> getAndIncrementSupplier;
+        private Supplier<Integer> getSupplier;
+        private Consumer<Long> setCountConsumer;
+
+        public Builder withStartRunnable(Runnable startRunnable) {
+            this.startRunnable = startRunnable;
+            return this;
+        }
+
+        public Builder withShutdownConsumer(Consumer<JobStatus> shutdownConsumer) {
+            this.shutdownConsumer = shutdownConsumer;
+            return this;
+        }
+
+        public Builder withGetAndIncrementSupplier(Supplier<Integer> getAndIncrementSupplier) {
+            this.getAndIncrementSupplier = getAndIncrementSupplier;
+            return this;
+        }
+
+        public Builder withGetSupplier(Supplier<Integer> getSupplier) {
+            this.getSupplier = getSupplier;
+            return this;
+        }
+
+        public Builder withSetCountConsumer(Consumer<Long> setCountConsumer) {
+            this.setCountConsumer = setCountConsumer;
+            return this;
+        }
+
+        public TestingCheckpointIDCounter build() {
+            return new TestingCheckpointIDCounter(
+                    startRunnable,
+                    shutdownConsumer,
+                    getAndIncrementSupplier,
+                    getSupplier,
+                    setCountConsumer);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
@@ -19,18 +19,54 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.util.function.TriFunction;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 /** Test {@link CompletedCheckpointStore} implementation for testing the shutdown behavior. */
 public final class TestingCompletedCheckpointStore implements CompletedCheckpointStore {
 
-    private final CompletableFuture<JobStatus> shutdownStatus;
+    private final TriFunction<
+                    CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+            addCheckpointAndSubsumeOldestOneFunction;
+    private final BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer;
+    private final Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier;
+    private final Supplier<Integer> getNumberOfRetainedCheckpointsSuppler;
+    private final Supplier<Integer> getMaxNumberOfRetainedCheckpointsSupplier;
+    private final Supplier<Boolean> requiresExternalizedCheckpointsSupplier;
+    private final Supplier<SharedStateRegistry> getSharedStateRegistrySupplier;
 
-    public TestingCompletedCheckpointStore(CompletableFuture<JobStatus> shutdownStatus) {
-        this.shutdownStatus = shutdownStatus;
+    public static TestingCompletedCheckpointStore
+            createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                    CompletableFuture<JobStatus> shutdownFuture) {
+        return TestingCompletedCheckpointStore.builder()
+                .withShutdownConsumer(
+                        ((jobStatus, ignoredCheckpointsCleaner) ->
+                                shutdownFuture.complete(jobStatus)))
+                .withGetAllCheckpointsSupplier(Collections::emptyList)
+                .build();
+    }
+
+    private TestingCompletedCheckpointStore(
+            TriFunction<CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+                    addCheckpointAndSubsumeOldestOneFunction,
+            BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer,
+            Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier,
+            Supplier<Integer> getNumberOfRetainedCheckpointsSuppler,
+            Supplier<Integer> getMaxNumberOfRetainedCheckpointsSupplier,
+            Supplier<Boolean> requiresExternalizedCheckpointsSupplier,
+            Supplier<SharedStateRegistry> getSharedStateRegistrySupplier) {
+        this.addCheckpointAndSubsumeOldestOneFunction = addCheckpointAndSubsumeOldestOneFunction;
+        this.shutdownConsumer = shutdownConsumer;
+        this.getAllCheckpointsSupplier = getAllCheckpointsSupplier;
+        this.getNumberOfRetainedCheckpointsSuppler = getNumberOfRetainedCheckpointsSuppler;
+        this.getMaxNumberOfRetainedCheckpointsSupplier = getMaxNumberOfRetainedCheckpointsSupplier;
+        this.requiresExternalizedCheckpointsSupplier = requiresExternalizedCheckpointsSupplier;
+        this.getSharedStateRegistrySupplier = getSharedStateRegistrySupplier;
     }
 
     @Override
@@ -38,41 +74,138 @@ public final class TestingCompletedCheckpointStore implements CompletedCheckpoin
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,
             Runnable postCleanup) {
-        throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    public CompletedCheckpoint getLatestCheckpoint() {
-        return null;
+        return addCheckpointAndSubsumeOldestOneFunction.apply(
+                checkpoint, checkpointsCleaner, postCleanup);
     }
 
     @Override
     public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner) {
-        shutdownStatus.complete(jobStatus);
+        shutdownConsumer.accept(jobStatus, checkpointsCleaner);
     }
 
     @Override
     public List<CompletedCheckpoint> getAllCheckpoints() {
-        return Collections.emptyList();
+        return getAllCheckpointsSupplier.get();
     }
 
     @Override
     public int getNumberOfRetainedCheckpoints() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getNumberOfRetainedCheckpointsSuppler.get();
     }
 
     @Override
     public int getMaxNumberOfRetainedCheckpoints() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getMaxNumberOfRetainedCheckpointsSupplier.get();
     }
 
     @Override
     public boolean requiresExternalizedCheckpoints() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return requiresExternalizedCheckpointsSupplier.get();
     }
 
     @Override
     public SharedStateRegistry getSharedStateRegistry() {
-        throw new UnsupportedOperationException("Not implemented.");
+        return getSharedStateRegistrySupplier.get();
+    }
+
+    public static Builder builder() {
+        return new TestingCompletedCheckpointStore.Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingCompletedCheckpointStore} instances. */
+    public static class Builder {
+
+        private TriFunction<CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+                addCheckpointAndSubsumeOldestOneFunction =
+                        (ignoredCompletedCheckpoint,
+                                ignoredCheckpointsCleaner,
+                                ignoredPostCleanup) -> {
+                            throw new UnsupportedOperationException(
+                                    "addCheckpointAndSubsumeOldestOne is not implemented.");
+                        };
+        private BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer =
+                (ignoredJobStatus, ignoredCheckpointsCleaner) -> {
+                    throw new UnsupportedOperationException("shutdown is not implemented.");
+                };
+        private Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getAllCheckpoints is not implemented.");
+                };
+        private Supplier<Integer> getNumberOfRetainedCheckpointsSuppler =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getNumberOfRetainedCheckpointsis not implemented.");
+                };
+        private Supplier<Integer> getMaxNumberOfRetainedCheckpointsSupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getMaxNumberOfRetainedCheckpoints is not implemented.");
+                };
+        private Supplier<Boolean> requiresExternalizedCheckpointsSupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "requiresExternalizedCheckpoints is not implemented.");
+                };
+        private Supplier<SharedStateRegistry> getSharedStateRegistrySupplier =
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "getSharedStateRegistry is not implemented.");
+                };
+
+        public Builder withAddCheckpointAndSubsumeOldestOneFunction(
+                TriFunction<CompletedCheckpoint, CheckpointsCleaner, Runnable, CompletedCheckpoint>
+                        addCheckpointAndSubsumeOldestOneFunction) {
+            this.addCheckpointAndSubsumeOldestOneFunction =
+                    addCheckpointAndSubsumeOldestOneFunction;
+            return this;
+        }
+
+        public Builder withShutdownConsumer(
+                BiConsumer<JobStatus, CheckpointsCleaner> shutdownConsumer) {
+            this.shutdownConsumer = shutdownConsumer;
+            return this;
+        }
+
+        public Builder withGetAllCheckpointsSupplier(
+                Supplier<List<CompletedCheckpoint>> getAllCheckpointsSupplier) {
+            this.getAllCheckpointsSupplier = getAllCheckpointsSupplier;
+            return this;
+        }
+
+        public Builder withGetNumberOfRetainedCheckpointsSupplier(
+                Supplier<Integer> getNumberOfRetainedCheckpointsSuppler) {
+            this.getNumberOfRetainedCheckpointsSuppler = getNumberOfRetainedCheckpointsSuppler;
+            return this;
+        }
+
+        public Builder withGetMaxNumberOfRetainedCheckpointsSupplier(
+                Supplier<Integer> getMaxNumberOfRetainedCheckpoints) {
+            this.getMaxNumberOfRetainedCheckpointsSupplier = getMaxNumberOfRetainedCheckpoints;
+            return this;
+        }
+
+        public Builder withRequiresExternalizedCheckpointsSupplier(
+                Supplier<Boolean> requiresExternalizedCheckpointsSupplier) {
+            this.requiresExternalizedCheckpointsSupplier = requiresExternalizedCheckpointsSupplier;
+            return this;
+        }
+
+        public Builder withGetSharedStateRegistrySupplier(
+                Supplier<SharedStateRegistry> getSharedStateRegistrySupplier) {
+            this.getSharedStateRegistrySupplier = getSharedStateRegistrySupplier;
+            return this;
+        }
+
+        public TestingCompletedCheckpointStore build() {
+            return new TestingCompletedCheckpointStore(
+                    addCheckpointAndSubsumeOldestOneFunction,
+                    shutdownConsumer,
+                    getAllCheckpointsSupplier,
+                    getNumberOfRetainedCheckpointsSuppler,
+                    getMaxNumberOfRetainedCheckpointsSupplier,
+                    requiresExternalizedCheckpointsSupplier,
+                    getSharedStateRegistrySupplier);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -89,7 +89,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
                 maxNumberOfCheckpointsToRetain,
                 checkpointsInZooKeeper,
                 checkpointStoreUtil,
-                DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                CompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                         checkpointsInZooKeeper, checkpointStoreUtil),
                 SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor(), emptyList()),
                 executor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -104,7 +104,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
                 assertThrows(
                         Exception.class,
                         () ->
-                                DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                                CompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                                         checkpointsInZooKeeper, zooKeeperCheckpointStoreUtil));
         assertThat(exception, FlinkMatchers.containsCause(ExpectedTestException.class));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -26,18 +26,10 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmanager.StandaloneJobGraphStore;
-import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -52,11 +44,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 
 /** Abstract test for the {@link Dispatcher} component. */
 public class AbstractDispatcherTest extends TestLogger {
@@ -116,6 +103,19 @@ public class AbstractDispatcherTest extends TestLogger {
                 new BlobServer(configuration, temporaryFolder.newFolder(), new VoidBlobStore());
     }
 
+    protected TestingDispatcher.Builder createTestingDispatcherBuilder() {
+        return TestingDispatcher.builder()
+                .withRpcService(rpcService)
+                .withConfiguration(configuration)
+                .withHeartbeatServices(heartbeatServices)
+                .withHighAvailabilityServices(haServices)
+                .withJobGraphWriter(haServices.getJobGraphStore())
+                .withJobResultStore(haServices.getJobResultStore())
+                .withJobManagerRunnerFactory(JobMasterServiceLeadershipRunnerFactory.INSTANCE)
+                .withFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
+                .withBlobServer(blobServer);
+    }
+
     @After
     public void tearDown() throws Exception {
         if (haServices != null) {
@@ -128,116 +128,5 @@ public class AbstractDispatcherTest extends TestLogger {
 
     protected BlobServer getBlobServer() {
         return blobServer;
-    }
-
-    /** A convenient builder for the {@link TestingDispatcher}. */
-    public class TestingDispatcherBuilder {
-
-        private Collection<JobGraph> initialJobGraphs = Collections.emptyList();
-
-        private Collection<JobResult> dirtyJobResults = Collections.emptyList();
-
-        private DispatcherBootstrapFactory dispatcherBootstrapFactory =
-                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
-
-        private HeartbeatServices heartbeatServices = AbstractDispatcherTest.this.heartbeatServices;
-
-        private HighAvailabilityServices haServices = AbstractDispatcherTest.this.haServices;
-
-        private JobManagerRunnerFactory jobManagerRunnerFactory =
-                JobMasterServiceLeadershipRunnerFactory.INSTANCE;
-
-        private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
-
-        private JobResultStore jobResultStore = new EmbeddedJobResultStore();
-
-        private FatalErrorHandler fatalErrorHandler =
-                testingFatalErrorHandlerResource.getFatalErrorHandler();
-
-        private HistoryServerArchivist historyServerArchivist = VoidHistoryServerArchivist.INSTANCE;
-
-        TestingDispatcherBuilder setHeartbeatServices(HeartbeatServices heartbeatServices) {
-            this.heartbeatServices = heartbeatServices;
-            return this;
-        }
-
-        TestingDispatcherBuilder setHaServices(HighAvailabilityServices haServices) {
-            this.haServices = haServices;
-            return this;
-        }
-
-        TestingDispatcherBuilder setInitialJobGraphs(Collection<JobGraph> initialJobGraphs) {
-            this.initialJobGraphs = initialJobGraphs;
-            return this;
-        }
-
-        TestingDispatcherBuilder setDirtyJobResults(Collection<JobResult> dirtyJobResults) {
-            this.dirtyJobResults = dirtyJobResults;
-            return this;
-        }
-
-        TestingDispatcherBuilder setDispatcherBootstrapFactory(
-                DispatcherBootstrapFactory dispatcherBootstrapFactory) {
-            this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobManagerRunnerFactory(
-                JobManagerRunnerFactory jobManagerRunnerFactory) {
-            this.jobManagerRunnerFactory = jobManagerRunnerFactory;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobGraphWriter(JobGraphWriter jobGraphWriter) {
-            this.jobGraphWriter = jobGraphWriter;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobResultStore(JobResultStore jobResultStore) {
-            this.jobResultStore = jobResultStore;
-            return this;
-        }
-
-        public TestingDispatcherBuilder setFatalErrorHandler(FatalErrorHandler fatalErrorHandler) {
-            this.fatalErrorHandler = fatalErrorHandler;
-            return this;
-        }
-
-        public TestingDispatcherBuilder setHistoryServerArchivist(
-                HistoryServerArchivist historyServerArchivist) {
-            this.historyServerArchivist = historyServerArchivist;
-            return this;
-        }
-
-        TestingDispatcher build() throws Exception {
-            TestingResourceManagerGateway resourceManagerGateway =
-                    new TestingResourceManagerGateway();
-
-            final MemoryExecutionGraphInfoStore executionGraphInfoStore =
-                    new MemoryExecutionGraphInfoStore();
-
-            return new TestingDispatcher(
-                    rpcService,
-                    DispatcherId.generate(),
-                    initialJobGraphs,
-                    dirtyJobResults,
-                    dispatcherBootstrapFactory,
-                    new DispatcherServices(
-                            configuration,
-                            haServices,
-                            () -> CompletableFuture.completedFuture(resourceManagerGateway),
-                            blobServer,
-                            heartbeatServices,
-                            executionGraphInfoStore,
-                            fatalErrorHandler,
-                            historyServerArchivist,
-                            null,
-                            new DispatcherOperationCaches(),
-                            UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
-                            jobGraphWriter,
-                            jobResultStore,
-                            jobManagerRunnerFactory,
-                            ForkJoinPool.commonPool()));
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.CheckpointResourcesCleanupRunnerFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
@@ -112,6 +113,7 @@ public class AbstractDispatcherTest extends TestLogger {
                 .withJobGraphWriter(haServices.getJobGraphStore())
                 .withJobResultStore(haServices.getJobResultStore())
                 .withJobManagerRunnerFactory(JobMasterServiceLeadershipRunnerFactory.INSTANCE)
+                .withCleanupRunnerFactory(CheckpointResourcesCleanupRunnerFactory.INSTANCE)
                 .withFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
                 .withBlobServer(blobServer);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.FlinkAssertions;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.util.FlinkException;
@@ -47,9 +46,7 @@ public class DefaultJobManagerRunnerRegistryTest {
 
     @BeforeEach
     public void setup() {
-        testInstance =
-                new DefaultJobManagerRunnerRegistry(
-                        4, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        testInstance = new DefaultJobManagerRunnerRegistry(4);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
@@ -241,14 +241,10 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
             }
         }
         final TestingDispatcher dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(
-                                JobMasterServiceLeadershipRunnerFactory.INSTANCE)
-                        .setJobGraphWriter(haServices.getJobGraphStore())
-                        .setJobResultStore(haServices.getJobResultStore())
-                        .setInitialJobGraphs(jobGraphs)
-                        .setDirtyJobResults(haServices.getJobResultStore().getDirtyResults())
-                        .setFatalErrorHandler(
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(jobGraphs)
+                        .withRecoveredDirtyJobs(haServices.getJobResultStore().getDirtyResults())
+                        .withFatalErrorHandler(
                                 fatalErrorHandler == null
                                         ? testingFatalErrorHandlerResource.getFatalErrorHandler()
                                         : fatalErrorHandler)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -692,7 +692,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                             CompletableFuture.completedFuture(
                                                     new ExecutionGraphInfo(
                                                             ArchivedExecutionGraph
-                                                                    .createFromInitializingJob(
+                                                                    .createSparseArchivedExecutionGraph(
                                                                             jobGraph.getJobID(),
                                                                             jobGraph.getName(),
                                                                             JobStatus.RUNNING,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -149,8 +149,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     private TestingJobManagerRunnerFactory startDispatcherAndSubmitJob(
             TestingDispatcher.Builder dispatcherBuilder, int numBlockingJobManagerRunners)
             throws Exception {
-        final TestingJobManagerRunnerFactory testingJobManagerRunnerFactoryNG =
-                new TestingJobManagerRunnerFactory(numBlockingJobManagerRunners);
+        final TestingJobMasterServiceLeadershipRunnerFactory testingJobManagerRunnerFactoryNG =
+                new TestingJobMasterServiceLeadershipRunnerFactory(numBlockingJobManagerRunners);
         startDispatcher(dispatcherBuilder, testingJobManagerRunnerFactoryNG);
         submitJobAndWait();
 
@@ -650,7 +650,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     }
 
     private static final class BlockingJobManagerRunnerFactory
-            extends TestingJobManagerRunnerFactory {
+            extends TestingJobMasterServiceLeadershipRunnerFactory {
 
         private final ThrowingRunnable<Exception> jobManagerRunnerCreationLatch;
         private TestingJobManagerRunner testingRunner;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -41,15 +41,12 @@ import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
-import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -140,7 +137,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     private CompletableFuture<JobID> localCleanupFuture;
     private CompletableFuture<JobID> globalCleanupFuture;
     private CompletableFuture<JobID> cleanupJobHADataFuture;
-    private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
 
     @BeforeClass
     public static void setupClass() {
@@ -157,7 +153,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         highAvailabilityServices = new TestingHighAvailabilityServices();
         clearedJobLatch = new OneShotLatch();
         jobResultStore = new SingleJobResultStore(jobId, clearedJobLatch);
-        highAvailabilityServices.setJobResultStore(jobResultStore);
         cleanupJobHADataFuture = new CompletableFuture<>();
         highAvailabilityServices.setGlobalCleanupFuture(cleanupJobHADataFuture);
 
@@ -204,34 +199,16 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     }
 
     private void startDispatcher(JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
-        TestingResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
-        final HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
-        final MemoryExecutionGraphInfoStore archivedExecutionGraphStore =
-                new MemoryExecutionGraphInfoStore();
         dispatcher =
-                new TestingDispatcher(
-                        rpcService,
-                        DispatcherId.generate(),
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        (dispatcher, scheduledExecutor, errorHandler) ->
-                                new NoOpDispatcherBootstrap(),
-                        new DispatcherServices(
-                                configuration,
-                                highAvailabilityServices,
-                                () -> CompletableFuture.completedFuture(resourceManagerGateway),
-                                blobServer,
-                                heartbeatServices,
-                                archivedExecutionGraphStore,
-                                testingFatalErrorHandlerResource.getFatalErrorHandler(),
-                                VoidHistoryServerArchivist.INSTANCE,
-                                null,
-                                new DispatcherOperationCaches(),
-                                UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
-                                jobGraphWriter,
-                                jobResultStore,
-                                jobManagerRunnerFactory,
-                                ForkJoinPool.commonPool()));
+                TestingDispatcher.builder()
+                        .withRpcService(rpcService)
+                        .withHighAvailabilityServices(highAvailabilityServices)
+                        .withJobResultStore(jobResultStore)
+                        .withBlobServer(blobServer)
+                        .withFatalErrorHandler(
+                                testingFatalErrorHandlerResource.getFatalErrorHandler())
+                        .withJobManagerRunnerFactory(jobManagerRunnerFactory)
+                        .build();
 
         dispatcher.start();
 
@@ -242,6 +219,10 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     public void teardown() throws Exception {
         if (dispatcher != null) {
             dispatcher.close();
+        }
+
+        if (blobServer != null) {
+            blobServer.close();
         }
     }
 
@@ -665,7 +646,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                     throw new IOException("Expected IOException.");
                                 })
                         .build();
-        highAvailabilityServices.setJobResultStore(jobResultStore);
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 startDispatcherAndSubmitJob();
@@ -699,7 +679,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                     throw new IOException("Expected IOException.");
                                 })
                         .build();
-        highAvailabilityServices.setJobResultStore(jobResultStore);
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 startDispatcherAndSubmitJob();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.blob.TestingBlobStoreBuilder;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
-import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.dispatcher.cleanup.TestingResourceCleanerFactory;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -39,7 +38,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
-import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
@@ -74,10 +72,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -90,7 +86,6 @@ import static org.apache.flink.runtime.dispatcher.AbstractDispatcherTest.awaitSt
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Tests the resource cleanup by the {@link Dispatcher}. */
@@ -112,10 +107,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private JobGraph jobGraph;
 
-    private JobResultStore jobResultStore;
-
-    private OneShotLatch clearedJobLatch;
-
     private TestingDispatcher dispatcher;
 
     private DispatcherGateway dispatcherGateway;
@@ -135,9 +126,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
         jobId = jobGraph.getJobID();
 
-        clearedJobLatch = new OneShotLatch();
-        jobResultStore = new SingleJobResultStore(jobId, clearedJobLatch);
-
         globalCleanupFuture = new CompletableFuture<>();
         localCleanupFuture = new CompletableFuture<>();
 
@@ -154,46 +142,60 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private TestingJobManagerRunnerFactory startDispatcherAndSubmitJob(
             int numBlockingJobManagerRunners) throws Exception {
+        return startDispatcherAndSubmitJob(
+                createTestingDispatcherBuilder(), numBlockingJobManagerRunners);
+    }
+
+    private TestingJobManagerRunnerFactory startDispatcherAndSubmitJob(
+            TestingDispatcher.Builder dispatcherBuilder, int numBlockingJobManagerRunners)
+            throws Exception {
         final TestingJobManagerRunnerFactory testingJobManagerRunnerFactoryNG =
                 new TestingJobManagerRunnerFactory(numBlockingJobManagerRunners);
-        startDispatcher(testingJobManagerRunnerFactoryNG);
+        startDispatcher(dispatcherBuilder, testingJobManagerRunnerFactoryNG);
         submitJobAndWait();
 
         return testingJobManagerRunnerFactoryNG;
     }
 
     private void startDispatcher(JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
-        final JobManagerRunnerRegistry jobManagerRunnerRegistry =
-                new DefaultJobManagerRunnerRegistry(2);
-        dispatcher =
-                TestingDispatcher.builder()
-                        .withRpcService(rpcService)
-                        .withJobResultStore(jobResultStore)
-                        .withJobManagerRunnerRegistry(jobManagerRunnerRegistry)
-                        .withBlobServer(blobServer)
-                        .withFatalErrorHandler(
-                                testingFatalErrorHandlerResource.getFatalErrorHandler())
-                        .withResourceCleanerFactory(
-                                new TestingResourceCleanerFactory()
-                                        // JobManagerRunnerRegistry needs to be added explicitly
-                                        // because cleaning it will trigger the closeAsync latch
-                                        // provided by TestingJobManagerRunner
-                                        .withLocallyCleanableResource(jobManagerRunnerRegistry)
-                                        .withGloballyCleanableResource(
-                                                (jobId, executor) -> {
-                                                    globalCleanupFuture.complete(jobId);
-                                                    return FutureUtils.completedVoidFuture();
-                                                })
-                                        .withLocallyCleanableResource(
-                                                (jobId, executor) -> {
-                                                    localCleanupFuture.complete(jobId);
-                                                    return FutureUtils.completedVoidFuture();
-                                                }))
-                        .build();
+        startDispatcher(createTestingDispatcherBuilder(), jobManagerRunnerFactory);
+    }
+
+    private void startDispatcher(
+            TestingDispatcher.Builder dispatcherBuilder,
+            JobManagerRunnerFactory jobManagerRunnerFactory)
+            throws Exception {
+        dispatcher = dispatcherBuilder.withJobManagerRunnerFactory(jobManagerRunnerFactory).build();
 
         dispatcher.start();
 
         dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
+    }
+
+    private TestingDispatcher.Builder createTestingDispatcherBuilder() {
+        final JobManagerRunnerRegistry jobManagerRunnerRegistry =
+                new DefaultJobManagerRunnerRegistry(2);
+        return TestingDispatcher.builder()
+                .withRpcService(rpcService)
+                .withBlobServer(blobServer)
+                .withJobManagerRunnerRegistry(jobManagerRunnerRegistry)
+                .withFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
+                .withResourceCleanerFactory(
+                        new TestingResourceCleanerFactory()
+                                // JobManagerRunnerRegistry needs to be added explicitly
+                                // because cleaning it will trigger the closeAsync latch
+                                // provided by TestingJobManagerRunner
+                                .withLocallyCleanableResource(jobManagerRunnerRegistry)
+                                .withGloballyCleanableResource(
+                                        (jobId, ignoredExecutor) -> {
+                                            globalCleanupFuture.complete(jobId);
+                                            return FutureUtils.completedVoidFuture();
+                                        })
+                                .withLocallyCleanableResource(
+                                        (jobId, ignoredExecutor) -> {
+                                            localCleanupFuture.complete(jobId);
+                                            return FutureUtils.completedVoidFuture();
+                                        }));
     }
 
     @After
@@ -313,35 +315,86 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         assertGlobalCleanupTriggered(jobId);
     }
 
-    /**
-     * Tests that the {@link JobResultStore} entries are marked as clean after the job reached a
-     * terminal state.
-     */
     @Test
-    public void testJobResultStoreCleanup() throws Exception {
+    public void testJobBeingMarkedAsDirtyBeforeCleanup() throws Exception {
+        final OneShotLatch markAsDirtyLatch = new OneShotLatch();
+
+        final TestingDispatcher.Builder dispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .withJobResultStore(
+                                TestingJobResultStore.builder()
+                                        .withCreateDirtyResultConsumer(
+                                                ignoredJobResultEntry -> {
+                                                    try {
+                                                        markAsDirtyLatch.await();
+                                                    } catch (InterruptedException e) {
+                                                        throw new RuntimeException(e);
+                                                    }
+                                                })
+                                        .build());
+
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                startDispatcherAndSubmitJob();
+                startDispatcherAndSubmitJob(dispatcherBuilder, 0);
 
-        final JobResult jobResult =
-                TestingJobResultStore.createJobResult(jobId, ApplicationStatus.UNKNOWN);
+        finishJob(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
 
-        jobResultStore.createDirtyResult(new JobResultEntry(jobResult));
-        assertTrue(jobResultStore.hasJobResultEntry(jobId));
+        assertThatNoCleanupWasTriggered();
 
-        final TestingJobManagerRunner testingJobManagerRunner =
-                jobManagerRunnerFactory.takeCreatedJobManagerRunner();
-        testingJobManagerRunner.completeResultFuture(
-                new ExecutionGraphInfo(
-                        new ArchivedExecutionGraphBuilder()
-                                .setState(JobStatus.FINISHED)
-                                .setJobID(jobId)
-                                .build()));
+        markAsDirtyLatch.trigger();
 
-        // wait for the clearing
-        clearedJobLatch.await();
+        assertGlobalCleanupTriggered(jobId);
+    }
 
-        assertTrue(jobResultStore.hasJobResultEntry(jobId));
-        assertTrue(jobResultStore.getDirtyResults().isEmpty());
+    @Test
+    public void testJobBeingMarkedAsCleanAfterCleanup() throws Exception {
+        final CompletableFuture<JobID> markAsCleanFuture = new CompletableFuture<>();
+
+        final JobResultStore jobResultStore =
+                TestingJobResultStore.builder()
+                        .withMarkResultAsCleanConsumer(markAsCleanFuture::complete)
+                        .build();
+        final OneShotLatch localCleanupLatch = new OneShotLatch();
+        final OneShotLatch globalCleanupLatch = new OneShotLatch();
+        final TestingResourceCleanerFactory resourceCleanerFactory =
+                new TestingResourceCleanerFactory()
+                        .withLocallyCleanableResource(
+                                (ignoredJobId, ignoredExecutor) -> {
+                                    try {
+                                        localCleanupLatch.await();
+                                    } catch (InterruptedException e) {
+                                        throw new RuntimeException(e);
+                                    }
+
+                                    return FutureUtils.completedVoidFuture();
+                                })
+                        .withGloballyCleanableResource(
+                                (ignoredJobId, ignoredExecutor) -> {
+                                    try {
+                                        globalCleanupLatch.await();
+                                    } catch (InterruptedException e) {
+                                        throw new RuntimeException(e);
+                                    }
+
+                                    return FutureUtils.completedVoidFuture();
+                                });
+
+        final TestingDispatcher.Builder dispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .withJobResultStore(jobResultStore)
+                        .withResourceCleanerFactory(resourceCleanerFactory);
+
+        final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
+                startDispatcherAndSubmitJob(dispatcherBuilder, 0);
+
+        finishJob(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
+
+        assertThat(markAsCleanFuture.isDone(), is(false));
+
+        localCleanupLatch.trigger();
+        assertThat(markAsCleanFuture.isDone(), is(false));
+        globalCleanupLatch.trigger();
+
+        assertThat(markAsCleanFuture.get(), is(jobId));
     }
 
     /**
@@ -469,65 +522,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         dispatcherTerminationFuture.get();
     }
 
-    private static final class SingleJobResultStore implements JobResultStore {
-
-        private final JobID expectedJobId;
-        @Nullable private JobResultEntry actualJobResultEntry;
-        private boolean isDirty = true;
-
-        private final OneShotLatch clearedJobLatch;
-
-        private SingleJobResultStore(JobID expectedJobId, OneShotLatch clearedJobLatch) {
-            this.expectedJobId = expectedJobId;
-            this.clearedJobLatch = clearedJobLatch;
-        }
-
-        @Override
-        public void createDirtyResult(JobResultEntry jobResultEntry) throws IOException {
-            checkJobId(jobResultEntry.getJobId());
-            this.actualJobResultEntry = jobResultEntry;
-        }
-
-        private void checkJobId(JobID jobID) {
-            Preconditions.checkArgument(expectedJobId.equals(jobID));
-        }
-
-        @Override
-        public void markResultAsClean(JobID jobId) throws IOException {
-            checkJobId(jobId);
-            Preconditions.checkNotNull(actualJobResultEntry);
-            isDirty = false;
-            clearedJobLatch.trigger();
-        }
-
-        @Override
-        public boolean hasDirtyJobResultEntry(JobID jobId) throws IOException {
-            if (actualJobResultEntry == null) {
-                return false;
-            }
-
-            checkJobId(jobId);
-            return isDirty;
-        }
-
-        @Override
-        public boolean hasCleanJobResultEntry(JobID jobId) throws IOException {
-            if (actualJobResultEntry == null) {
-                return false;
-            }
-
-            checkJobId(jobId);
-            return !isDirty;
-        }
-
-        @Override
-        public Set<JobResult> getDirtyResults() throws IOException {
-            return actualJobResultEntry != null && isDirty
-                    ? Collections.singleton(actualJobResultEntry.getJobResult())
-                    : Collections.emptySet();
-        }
-    }
-
     private void assertLocalCleanupTriggered(JobID jobId)
             throws ExecutionException, InterruptedException, TimeoutException {
         assertThat(localCleanupFuture.get(100, TimeUnit.MILLISECONDS), equalTo(jobId));
@@ -542,7 +536,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     @Test
     public void testFatalErrorIfJobCannotBeMarkedDirtyInJobResultStore() throws Exception {
-        jobResultStore =
+        final JobResultStore jobResultStore =
                 TestingJobResultStore.builder()
                         .withCreateDirtyResultConsumer(
                                 jobResult -> {
@@ -551,7 +545,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                         .build();
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                startDispatcherAndSubmitJob();
+                startDispatcherAndSubmitJob(
+                        createTestingDispatcherBuilder().withJobResultStore(jobResultStore), 0);
 
         ArchivedExecutionGraph executionGraph =
                 new ArchivedExecutionGraphBuilder()
@@ -574,7 +569,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     @Test
     public void testErrorHandlingIfJobCannotBeMarkedAsCleanInJobResultStore() throws Exception {
         final CompletableFuture<JobResultEntry> dirtyJobFuture = new CompletableFuture<>();
-        jobResultStore =
+        final JobResultStore jobResultStore =
                 TestingJobResultStore.builder()
                         .withCreateDirtyResultConsumer(dirtyJobFuture::complete)
                         .withMarkResultAsCleanConsumer(
@@ -584,7 +579,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                         .build();
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                startDispatcherAndSubmitJob();
+                startDispatcherAndSubmitJob(
+                        createTestingDispatcherBuilder().withJobResultStore(jobResultStore), 0);
 
         ArchivedExecutionGraph executionGraph =
                 new ArchivedExecutionGraphBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -525,7 +525,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
         testingJobManagerRunner.completeResultFuture(
                 JobManagerRunnerResult.forInitializationFailure(
                         new ExecutionGraphInfo(
-                                ArchivedExecutionGraph.createFromInitializingJob(
+                                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                                         jobId,
                                         jobGraph.getName(),
                                         JobStatus.FAILED,
@@ -686,7 +686,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
         testingJobManagerRunner.completeResultFuture(
                 JobManagerRunnerResult.forInitializationFailure(
                         new ExecutionGraphInfo(
-                                ArchivedExecutionGraph.createFromInitializingJob(
+                                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                                         jobId,
                                         jobGraph.getName(),
                                         JobStatus.FAILED,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -59,7 +59,6 @@ import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceProce
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
 import org.apache.flink.runtime.jobmaster.factories.TestingJobMasterServiceFactory;
-import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
@@ -89,7 +88,6 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
@@ -110,11 +108,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -127,12 +123,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
-import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -726,83 +720,6 @@ public class DispatcherTest extends AbstractDispatcherTest {
                         .build();
     }
 
-    /** Tests that a failing {@link JobManagerRunner} will be properly cleaned up. */
-    @Test
-    public void testFailingJobManagerRunnerCleanup() throws Exception {
-        final FlinkException testException = new FlinkException("Test exception.");
-        final ArrayBlockingQueue<Optional<Exception>> queue = new ArrayBlockingQueue<>(2);
-
-        final BlockingJobManagerRunnerFactory blockingJobManagerRunnerFactory =
-                new BlockingJobManagerRunnerFactory(
-                        () -> {
-                            final Optional<Exception> maybeException = queue.take();
-                            if (maybeException.isPresent()) {
-                                throw maybeException.get();
-                            }
-                        });
-
-        final BlockingQueue<String> cleanUpEvents = new LinkedBlockingQueue<>();
-
-        // Track cleanup - ha-services
-        final CompletableFuture<JobID> cleanupJobData = new CompletableFuture<>();
-        haServices.setGlobalCleanupFuture(cleanupJobData);
-        cleanupJobData.thenAccept(jobId -> cleanUpEvents.add(CLEANUP_HA_SERVICES));
-
-        // Track cleanup - job-graph
-        final TestingJobGraphStore jobGraphStore =
-                TestingJobGraphStore.newBuilder()
-                        .setLocalCleanupFunction(
-                                (jobId, executor) -> {
-                                    cleanUpEvents.add(CLEANUP_JOB_GRAPH_RELEASE);
-                                    return FutureUtils.completedVoidFuture();
-                                })
-                        .setGlobalCleanupFunction(
-                                (jobId, executor) -> {
-                                    cleanUpEvents.add(CLEANUP_JOB_GRAPH_REMOVE);
-                                    return FutureUtils.completedVoidFuture();
-                                })
-                        .build();
-        jobGraphStore.start(null);
-        haServices.setJobGraphStore(jobGraphStore);
-
-        // Track cleanup - job result store
-        haServices.setJobResultStore(
-                TestingJobResultStore.builder()
-                        .withMarkResultAsCleanConsumer(
-                                jobID -> cleanUpEvents.add(CLEANUP_JOB_RESULT_STORE))
-                        .build());
-
-        dispatcher =
-                createAndStartDispatcher(
-                        heartbeatServices, haServices, blockingJobManagerRunnerFactory);
-
-        final DispatcherGateway dispatcherGateway =
-                dispatcher.getSelfGateway(DispatcherGateway.class);
-
-        // submit and fail during job master runner construction
-        queue.offer(Optional.of(testException));
-        try {
-            dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
-            fail("A FlinkException is expected");
-        } catch (Throwable expectedException) {
-            assertThat(expectedException, containsCause(FlinkException.class));
-            assertThat(expectedException, containsMessage(testException.getMessage()));
-            // make sure we've cleaned up in correct order (including HA)
-            assertThat(
-                    new ArrayList<>(cleanUpEvents),
-                    containsInAnyOrder(CLEANUP_JOB_GRAPH_REMOVE, CLEANUP_HA_SERVICES));
-        }
-
-        // don't fail this time
-        queue.offer(Optional.empty());
-        // submit job again
-        dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
-        blockingJobManagerRunnerFactory.setJobStatus(JobStatus.RUNNING);
-
-        // Ensure job is running
-        awaitStatus(dispatcherGateway, jobId, JobStatus.RUNNING);
-    }
-
     @Test
     public void testPersistedJobGraphWhenDispatcherIsShutDown() throws Exception {
         final TestingJobGraphStore submittedJobGraphStore =
@@ -1361,70 +1278,6 @@ public class DispatcherTest extends AbstractDispatcherTest {
                 return future.whenComplete((r, t) -> super.closeAsync());
             }
             return super.closeAsync();
-        }
-    }
-
-    private static final class BlockingJobManagerRunnerFactory
-            extends TestingJobManagerRunnerFactory {
-
-        @Nonnull private final ThrowingRunnable<Exception> jobManagerRunnerCreationLatch;
-        private TestingJobManagerRunner testingRunner;
-
-        BlockingJobManagerRunnerFactory(
-                @Nonnull ThrowingRunnable<Exception> jobManagerRunnerCreationLatch) {
-            this.jobManagerRunnerCreationLatch = jobManagerRunnerCreationLatch;
-        }
-
-        @Override
-        public TestingJobManagerRunner createJobManagerRunner(
-                JobGraph jobGraph,
-                Configuration configuration,
-                RpcService rpcService,
-                HighAvailabilityServices highAvailabilityServices,
-                HeartbeatServices heartbeatServices,
-                JobManagerSharedServices jobManagerSharedServices,
-                JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-                FatalErrorHandler fatalErrorHandler,
-                long initializationTimestamp)
-                throws Exception {
-            jobManagerRunnerCreationLatch.run();
-
-            this.testingRunner =
-                    super.createJobManagerRunner(
-                            jobGraph,
-                            configuration,
-                            rpcService,
-                            highAvailabilityServices,
-                            heartbeatServices,
-                            jobManagerSharedServices,
-                            jobManagerJobMetricGroupFactory,
-                            fatalErrorHandler,
-                            initializationTimestamp);
-
-            TestingJobMasterGateway testingJobMasterGateway =
-                    new TestingJobMasterGatewayBuilder()
-                            .setRequestJobSupplier(
-                                    () ->
-                                            CompletableFuture.completedFuture(
-                                                    new ExecutionGraphInfo(
-                                                            ArchivedExecutionGraph
-                                                                    .createFromInitializingJob(
-                                                                            jobGraph.getJobID(),
-                                                                            jobGraph.getName(),
-                                                                            JobStatus.RUNNING,
-                                                                            null,
-                                                                            null,
-                                                                            1337))))
-                            .build();
-            testingRunner.completeJobMasterGatewayFuture(testingJobMasterGateway);
-            return testingRunner;
-        }
-
-        public void setJobStatus(JobStatus newStatus) {
-            Preconditions.checkState(
-                    testingRunner != null,
-                    "JobManagerRunner must be created before this method is available");
-            this.testingRunner.setJobStatus(newStatus);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -504,8 +504,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
 
     @Test
     public void testJobManagerRunnerInitializationFailureFailsJob() throws Exception {
-        final TestingJobManagerRunnerFactory testingJobManagerRunnerFactory =
-                new TestingJobManagerRunnerFactory();
+        final TestingJobMasterServiceLeadershipRunnerFactory testingJobManagerRunnerFactory =
+                new TestingJobMasterServiceLeadershipRunnerFactory();
 
         dispatcher =
                 createAndStartDispatcher(
@@ -666,8 +666,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final FlinkException testException = new FlinkException("Test exception");
         jobMasterLeaderElectionService.isLeader(UUID.randomUUID());
 
-        final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                new TestingJobManagerRunnerFactory();
+        final TestingJobMasterServiceLeadershipRunnerFactory jobManagerRunnerFactory =
+                new TestingJobMasterServiceLeadershipRunnerFactory();
         dispatcher =
                 createTestingDispatcherBuilder()
                         .withJobManagerRunnerFactory(jobManagerRunnerFactory)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -178,12 +178,12 @@ public class DispatcherTest extends AbstractDispatcherTest {
             JobManagerRunnerFactory jobManagerRunnerFactory)
             throws Exception {
         final TestingDispatcher dispatcher =
-                new TestingDispatcherBuilder()
-                        .setHaServices(haServices)
-                        .setHeartbeatServices(heartbeatServices)
-                        .setJobManagerRunnerFactory(jobManagerRunnerFactory)
-                        .setJobGraphWriter(haServices.getJobGraphStore())
-                        .setJobResultStore(haServices.getJobResultStore())
+                createTestingDispatcherBuilder()
+                        .withHighAvailabilityServices(haServices)
+                        .withHeartbeatServices(heartbeatServices)
+                        .withJobManagerRunnerFactory(jobManagerRunnerFactory)
+                        .withJobGraphWriter(haServices.getJobGraphStore())
+                        .withJobResultStore(haServices.getJobResultStore())
                         .build();
         dispatcher.start();
         return dispatcher;
@@ -246,11 +246,11 @@ public class DispatcherTest extends AbstractDispatcherTest {
     @Test
     public void testDuplicateJobSubmissionWithRunningJobId() throws Exception {
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(
+                createTestingDispatcherBuilder()
+                        .withJobManagerRunnerFactory(
                                 new ExpectedJobIdJobManagerRunnerFactory(
                                         jobId, createdJobManagerRunnerLatch))
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
+                        .withRecoveredJobs(Collections.singleton(jobGraph))
                         .build();
         dispatcher.start();
         final DispatcherGateway dispatcherGateway =
@@ -474,11 +474,11 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final CompletableFuture<JobManagerRunnerResult> jobTerminationFuture =
                 new CompletableFuture<>();
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(
+                createTestingDispatcherBuilder()
+                        .withJobManagerRunnerFactory(
                                 new FinishingJobManagerRunnerFactory(
                                         jobTerminationFuture, () -> {}))
-                        .setHistoryServerArchivist(
+                        .withHistoryServerArchivist(
                                 executionGraphInfo -> {
                                     archiveAttemptFuture.complete(null);
                                     return CompletableFuture.completedFuture(null);
@@ -675,10 +675,9 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 new TestingJobManagerRunnerFactory();
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(jobManagerRunnerFactory)
-                        .setInitialJobGraphs(
-                                Collections.singleton(JobGraphTestUtils.emptyJobGraph()))
+                createTestingDispatcherBuilder()
+                        .withJobManagerRunnerFactory(jobManagerRunnerFactory)
+                        .withRecoveredJobs(Collections.singleton(JobGraphTestUtils.emptyJobGraph()))
                         .build();
 
         dispatcher.start();
@@ -721,9 +720,9 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final JobResult jobResult =
                 TestingJobResultStore.createSuccessfulJobResult(jobGraph.getJobID());
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
-                        .setDirtyJobResults(Collections.singleton(jobResult))
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(Collections.singleton(jobGraph))
+                        .withRecoveredDirtyJobs(Collections.singleton(jobResult))
                         .build();
     }
 
@@ -812,7 +811,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
         haServices.setJobGraphStore(submittedJobGraphStore);
 
         dispatcher =
-                new TestingDispatcherBuilder().setJobGraphWriter(submittedJobGraphStore).build();
+                createTestingDispatcherBuilder().withJobGraphWriter(submittedJobGraphStore).build();
 
         dispatcher.start();
 
@@ -930,9 +929,9 @@ public class DispatcherTest extends AbstractDispatcherTest {
         testingJobGraphStore.start(null);
 
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
-                        .setJobGraphWriter(testingJobGraphStore)
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(Collections.singleton(jobGraph))
+                        .withJobGraphWriter(testingJobGraphStore)
                         .build();
         dispatcher.start();
 
@@ -1110,8 +1109,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final PermanentBlobKey blobKey2 = blobServer.putPermanent(jobId2, fileContent);
 
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(new JobGraph(jobId1, "foobar")))
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(Collections.singleton(new JobGraph(jobId1, "foobar")))
                         .build();
 
         Assertions.assertThat(blobServer.getFile(jobId1, blobKey1)).hasBinaryContent(fileContent);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingCleanupRunnerFactory;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
@@ -718,6 +719,51 @@ public class DispatcherTest extends AbstractDispatcherTest {
                         .withRecoveredJobs(Collections.singleton(jobGraph))
                         .withRecoveredDirtyJobs(Collections.singleton(jobResult))
                         .build();
+    }
+
+    @Test
+    public void testJobCleanupWithoutRecoveredJobGraph() throws Exception {
+        final JobID jobIdOfRecoveredDirtyJobs = new JobID();
+        final TestingJobMasterServiceLeadershipRunnerFactory jobManagerRunnerFactory =
+                new TestingJobMasterServiceLeadershipRunnerFactory();
+        final TestingCleanupRunnerFactory cleanupRunnerFactory = new TestingCleanupRunnerFactory();
+
+        final OneShotLatch dispatcherBootstrapLatch = new OneShotLatch();
+        dispatcher =
+                createTestingDispatcherBuilder()
+                        .withJobManagerRunnerFactory(jobManagerRunnerFactory)
+                        .withCleanupRunnerFactory(cleanupRunnerFactory)
+                        .withRecoveredDirtyJobs(
+                                Collections.singleton(
+                                        new JobResult.Builder()
+                                                .jobId(jobIdOfRecoveredDirtyJobs)
+                                                .applicationStatus(ApplicationStatus.SUCCEEDED)
+                                                .netRuntime(1)
+                                                .build()))
+                        .withDispatcherBootstrapFactory(
+                                (ignoredDispatcherGateway,
+                                        ignoredScheduledExecutor,
+                                        ignoredFatalErrorHandler) -> {
+                                    dispatcherBootstrapLatch.trigger();
+                                    return new NoOpDispatcherBootstrap();
+                                })
+                        .build();
+
+        dispatcher.start();
+
+        dispatcherBootstrapLatch.await();
+
+        final TestingJobManagerRunner cleanupRunner =
+                cleanupRunnerFactory.takeCreatedJobManagerRunner();
+        assertThat(
+                "The CleanupJobManagerRunner has the wrong job ID attached.",
+                cleanupRunner.getJobID(),
+                is(jobIdOfRecoveredDirtyJobs));
+
+        assertThat(
+                "No JobMaster should have been started.",
+                jobManagerRunnerFactory.getQueueSize(),
+                is(0));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingCleanupRunnerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
@@ -96,7 +96,8 @@ public class MiniDispatcherTest extends TestLogger {
 
     private TestingHighAvailabilityServices highAvailabilityServices;
 
-    private TestingJobManagerRunnerFactory testingJobManagerRunnerFactory;
+    private TestingJobMasterServiceLeadershipRunnerFactory testingJobManagerRunnerFactory;
+    private TestingCleanupRunnerFactory testingCleanupRunnerFactory;
 
     @BeforeClass
     public static void setupClass() throws IOException {
@@ -120,7 +121,8 @@ public class MiniDispatcherTest extends TestLogger {
     public void setup() throws Exception {
         highAvailabilityServices = new TestingHighAvailabilityServicesBuilder().build();
 
-        testingJobManagerRunnerFactory = new TestingJobManagerRunnerFactory();
+        testingJobManagerRunnerFactory = new TestingJobMasterServiceLeadershipRunnerFactory();
+        testingCleanupRunnerFactory = new TestingCleanupRunnerFactory();
     }
 
     @AfterClass
@@ -156,22 +158,19 @@ public class MiniDispatcherTest extends TestLogger {
     /** Tests that the {@link MiniDispatcher} recovers the single job with which it was started. */
     @Test
     public void testDirtyJobResultCleanup() throws Exception {
-        final OneShotLatch dispatcherBootstrapLatch = new OneShotLatch();
+        final JobID jobId = new JobID();
         final MiniDispatcher miniDispatcher =
                 createMiniDispatcher(
                         ClusterEntrypoint.ExecutionMode.DETACHED,
                         null,
-                        TestingJobResultStore.createSuccessfulJobResult(new JobID()),
-                        (dispatcher, scheduledExecutor, errorHandler) -> {
-                            dispatcherBootstrapLatch.trigger();
-                            return new NoOpDispatcherBootstrap();
-                        });
+                        TestingJobResultStore.createSuccessfulJobResult(jobId));
 
         miniDispatcher.start();
 
         try {
-            dispatcherBootstrapLatch.await();
-            assertThat(testingJobManagerRunnerFactory.getQueueSize(), is(0));
+            final TestingJobManagerRunner testingCleanupRunner =
+                    testingCleanupRunnerFactory.takeCreatedJobManagerRunner();
+            assertThat(testingCleanupRunner.getJobID(), is(jobId));
         } finally {
             RpcUtils.terminateRpcEndpoint(miniDispatcher, timeout);
         }
@@ -303,18 +302,13 @@ public class MiniDispatcherTest extends TestLogger {
 
     private MiniDispatcher createMiniDispatcher(ClusterEntrypoint.ExecutionMode executionMode)
             throws Exception {
-        return createMiniDispatcher(
-                executionMode,
-                jobGraph,
-                null,
-                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap());
+        return createMiniDispatcher(executionMode, jobGraph, null);
     }
 
     private MiniDispatcher createMiniDispatcher(
             ClusterEntrypoint.ExecutionMode executionMode,
             @Nullable JobGraph recoveredJobGraph,
-            @Nullable JobResult recoveredDirtyJob,
-            DispatcherBootstrapFactory dispatcherBootstrapFactory)
+            @Nullable JobResult recoveredDirtyJob)
             throws Exception {
         return new MiniDispatcher(
                 rpcService,
@@ -334,10 +328,11 @@ public class MiniDispatcherTest extends TestLogger {
                         highAvailabilityServices.getJobGraphStore(),
                         highAvailabilityServices.getJobResultStore(),
                         testingJobManagerRunnerFactory,
+                        testingCleanupRunnerFactory,
                         ForkJoinPool.commonPool()),
                 recoveredJobGraph,
                 recoveredDirtyJob,
-                dispatcherBootstrapFactory,
+                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap(),
                 executionMode);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -20,16 +20,39 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.JobResultStore;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 /** {@link Dispatcher} implementation used for testing purposes. */
@@ -52,6 +75,57 @@ class TestingDispatcher extends Dispatcher {
                 recoveredDirtyJobResults,
                 dispatcherBootstrapFactory,
                 dispatcherServices);
+
+        this.startFuture = new CompletableFuture<>();
+    }
+
+    private TestingDispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> recoveredDirtyJobs,
+            Configuration configuration,
+            HighAvailabilityServices highAvailabilityServices,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            HeartbeatServices heartbeatServices,
+            BlobServer blobServer,
+            FatalErrorHandler fatalErrorHandler,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore,
+            JobManagerMetricGroup jobManagerMetricGroup,
+            @Nullable String metricServiceQueryAddress,
+            Executor ioExecutor,
+            HistoryServerArchivist historyServerArchivist,
+            ExecutionGraphInfoStore executionGraphInfoStore,
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            DispatcherOperationCaches dispatcherOperationCaches,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            ResourceCleanerFactory resourceCleanerFactory)
+            throws Exception {
+        super(
+                rpcService,
+                fencingToken,
+                recoveredJobs,
+                recoveredDirtyJobs,
+                configuration,
+                highAvailabilityServices,
+                resourceManagerGatewayRetriever,
+                heartbeatServices,
+                blobServer,
+                fatalErrorHandler,
+                jobGraphWriter,
+                jobResultStore,
+                jobManagerMetricGroup,
+                metricServiceQueryAddress,
+                ioExecutor,
+                historyServerArchivist,
+                executionGraphInfoStore,
+                jobManagerRunnerFactory,
+                dispatcherBootstrapFactory,
+                dispatcherOperationCaches,
+                jobManagerRunnerRegistry,
+                resourceCleanerFactory);
 
         this.startFuture = new CompletableFuture<>();
     }
@@ -90,5 +164,213 @@ class TestingDispatcher extends Dispatcher {
 
     void waitUntilStarted() {
         startFuture.join();
+    }
+
+    public static TestingDispatcher.Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private RpcService rpcService = new TestingRpcService();
+        private DispatcherId fencingToken = DispatcherId.generate();
+        private Collection<JobGraph> recoveredJobs = Collections.emptyList();
+        private Collection<JobResult> recoveredDirtyJobs = Collections.emptyList();
+        private HighAvailabilityServices highAvailabilityServices =
+                new TestingHighAvailabilityServices();
+
+        private TestingResourceManagerGateway resourceManagerGateway =
+                new TestingResourceManagerGateway();
+        private GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever =
+                () -> CompletableFuture.completedFuture(resourceManagerGateway);
+        private HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
+
+        private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
+        private JobResultStore jobResultStore = new EmbeddedJobResultStore();
+
+        private Configuration configuration = new Configuration();
+
+        // even-though it's labeled as @Nullable, it's a mandatory field that needs to be set before
+        // building the Dispatcher instance
+        @Nullable private BlobServer blobServer = null;
+        private FatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+        private JobManagerMetricGroup jobManagerMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup();
+        @Nullable private String metricServiceQueryAddress = null;
+        private Executor ioExecutor = ForkJoinPool.commonPool();
+        private HistoryServerArchivist historyServerArchivist = VoidHistoryServerArchivist.INSTANCE;
+        private ExecutionGraphInfoStore executionGraphInfoStore =
+                new MemoryExecutionGraphInfoStore();
+        private JobManagerRunnerFactory jobManagerRunnerFactory =
+                new TestingJobManagerRunnerFactory(0);
+        private DispatcherBootstrapFactory dispatcherBootstrapFactory =
+                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
+        private DispatcherOperationCaches dispatcherOperationCaches =
+                new DispatcherOperationCaches();
+        private JobManagerRunnerRegistry jobManagerRunnerRegistry =
+                new DefaultJobManagerRunnerRegistry(1);
+        @Nullable private ResourceCleanerFactory resourceCleanerFactory;
+
+        public Builder withRpcService(RpcService rpcService) {
+            this.rpcService = rpcService;
+            return this;
+        }
+
+        public Builder withFencingToken(DispatcherId fencingToken) {
+            this.fencingToken = fencingToken;
+            return this;
+        }
+
+        public Builder withRecoveredJobs(Collection<JobGraph> recoveredJobs) {
+            this.recoveredJobs = recoveredJobs;
+            return this;
+        }
+
+        public Builder withRecoveredDirtyJobs(Collection<JobResult> recoveredDirtyJobs) {
+            this.recoveredDirtyJobs = recoveredDirtyJobs;
+            return this;
+        }
+
+        public Builder withHighAvailabilityServices(
+                HighAvailabilityServices highAvailabilityServices) {
+            this.highAvailabilityServices = highAvailabilityServices;
+            return this;
+        }
+
+        public Builder withResourceManagerGateway(
+                TestingResourceManagerGateway resourceManagerGateway) {
+            this.resourceManagerGateway = resourceManagerGateway;
+            return this;
+        }
+
+        public Builder withResourceManagerGatewayRetriever(
+                GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) {
+            this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
+            return this;
+        }
+
+        public Builder withHeartbeatServices(HeartbeatServices heartbeatServices) {
+            this.heartbeatServices = heartbeatServices;
+            return this;
+        }
+
+        public Builder withJobGraphWriter(JobGraphWriter jobGraphWriter) {
+            this.jobGraphWriter = jobGraphWriter;
+            return this;
+        }
+
+        public Builder withJobResultStore(JobResultStore jobResultStore) {
+            this.jobResultStore = jobResultStore;
+            return this;
+        }
+
+        public Builder withConfiguration(Configuration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public Builder withBlobServer(BlobServer blobServer) {
+            this.blobServer = blobServer;
+            return this;
+        }
+
+        public Builder withFatalErrorHandler(FatalErrorHandler fatalErrorHandler) {
+            this.fatalErrorHandler = fatalErrorHandler;
+            return this;
+        }
+
+        public Builder withJobManagerMetricGroup(JobManagerMetricGroup jobManagerMetricGroup) {
+            this.jobManagerMetricGroup = jobManagerMetricGroup;
+            return this;
+        }
+
+        public Builder withMetricServiceQueryAddress(@Nullable String metricServiceQueryAddress) {
+            this.metricServiceQueryAddress = metricServiceQueryAddress;
+            return this;
+        }
+
+        public Builder withIoExecutor(Executor ioExecutor) {
+            this.ioExecutor = ioExecutor;
+            return this;
+        }
+
+        public Builder withHistoryServerArchivist(HistoryServerArchivist historyServerArchivist) {
+            this.historyServerArchivist = historyServerArchivist;
+            return this;
+        }
+
+        public Builder withExecutionGraphInfoStore(
+                ExecutionGraphInfoStore executionGraphInfoStore) {
+            this.executionGraphInfoStore = executionGraphInfoStore;
+            return this;
+        }
+
+        public Builder withJobManagerRunnerFactory(
+                JobManagerRunnerFactory jobManagerRunnerFactory) {
+            this.jobManagerRunnerFactory = jobManagerRunnerFactory;
+            return this;
+        }
+
+        public Builder withDispatcherBootstrapFactory(
+                DispatcherBootstrapFactory dispatcherBootstrapFactory) {
+            this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
+            return this;
+        }
+
+        public Builder withDispatcherOperationCaches(
+                DispatcherOperationCaches dispatcherOperationCaches) {
+            this.dispatcherOperationCaches = dispatcherOperationCaches;
+            return this;
+        }
+
+        public Builder withJobManagerRunnerRegistry(
+                JobManagerRunnerRegistry jobManagerRunnerRegistry) {
+            this.jobManagerRunnerRegistry = jobManagerRunnerRegistry;
+            return this;
+        }
+
+        public Builder withResourceCleanerFactory(ResourceCleanerFactory resourceCleanerFactory) {
+            this.resourceCleanerFactory = resourceCleanerFactory;
+            return this;
+        }
+
+        private ResourceCleanerFactory createDefaultResourceCleanerFactory() {
+            return new DispatcherResourceCleanerFactory(
+                    ioExecutor,
+                    jobManagerRunnerRegistry,
+                    jobGraphWriter,
+                    blobServer,
+                    highAvailabilityServices,
+                    jobManagerMetricGroup);
+        }
+
+        public TestingDispatcher build() throws Exception {
+            return new TestingDispatcher(
+                    rpcService,
+                    fencingToken,
+                    recoveredJobs,
+                    recoveredDirtyJobs,
+                    configuration,
+                    highAvailabilityServices,
+                    resourceManagerGatewayRetriever,
+                    heartbeatServices,
+                    Preconditions.checkNotNull(
+                            blobServer,
+                            "No BlobServer is specified for building the TestingDispatcher"),
+                    fatalErrorHandler,
+                    jobGraphWriter,
+                    jobResultStore,
+                    jobManagerMetricGroup,
+                    metricServiceQueryAddress,
+                    ioExecutor,
+                    historyServerArchivist,
+                    executionGraphInfoStore,
+                    jobManagerRunnerFactory,
+                    dispatcherBootstrapFactory,
+                    dispatcherOperationCaches,
+                    jobManagerRunnerRegistry,
+                    resourceCleanerFactory != null
+                            ? resourceCleanerFactory
+                            : createDefaultResourceCleanerFactory());
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -22,8 +22,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.dispatcher.cleanup.CleanupRunnerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.TestingCleanupRunnerFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.JobResultStore;
@@ -98,6 +100,7 @@ class TestingDispatcher extends Dispatcher {
             HistoryServerArchivist historyServerArchivist,
             ExecutionGraphInfoStore executionGraphInfoStore,
             JobManagerRunnerFactory jobManagerRunnerFactory,
+            CleanupRunnerFactory cleanupRunnerFactory,
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             DispatcherOperationCaches dispatcherOperationCaches,
             JobManagerRunnerRegistry jobManagerRunnerRegistry,
@@ -122,6 +125,7 @@ class TestingDispatcher extends Dispatcher {
                 historyServerArchivist,
                 executionGraphInfoStore,
                 jobManagerRunnerFactory,
+                cleanupRunnerFactory,
                 dispatcherBootstrapFactory,
                 dispatcherOperationCaches,
                 jobManagerRunnerRegistry,
@@ -201,7 +205,8 @@ class TestingDispatcher extends Dispatcher {
         private ExecutionGraphInfoStore executionGraphInfoStore =
                 new MemoryExecutionGraphInfoStore();
         private JobManagerRunnerFactory jobManagerRunnerFactory =
-                new TestingJobManagerRunnerFactory(0);
+                new TestingJobMasterServiceLeadershipRunnerFactory();
+        private CleanupRunnerFactory cleanupRunnerFactory = new TestingCleanupRunnerFactory();
         private DispatcherBootstrapFactory dispatcherBootstrapFactory =
                 (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
         private DispatcherOperationCaches dispatcherOperationCaches =
@@ -310,6 +315,11 @@ class TestingDispatcher extends Dispatcher {
             return this;
         }
 
+        public Builder withCleanupRunnerFactory(CleanupRunnerFactory cleanupRunnerFactory) {
+            this.cleanupRunnerFactory = cleanupRunnerFactory;
+            return this;
+        }
+
         public Builder withDispatcherBootstrapFactory(
                 DispatcherBootstrapFactory dispatcherBootstrapFactory) {
             this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
@@ -365,6 +375,7 @@ class TestingDispatcher extends Dispatcher {
                     historyServerArchivist,
                     executionGraphInfoStore,
                     jobManagerRunnerFactory,
+                    cleanupRunnerFactory,
                     dispatcherBootstrapFactory,
                     dispatcherOperationCaches,
                     jobManagerRunnerRegistry,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
@@ -18,18 +18,9 @@
 
 package org.apache.flink.runtime.dispatcher;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
-import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
-import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.Preconditions;
-
-import javax.annotation.Nonnull;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -39,46 +30,30 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Testing implementation of {@link JobManagerRunnerFactory} which returns a {@link
  * TestingJobManagerRunner}.
  */
-public class TestingJobManagerRunnerFactory implements JobManagerRunnerFactory {
+public class TestingJobManagerRunnerFactory {
 
     private final BlockingQueue<TestingJobManagerRunner> createdJobManagerRunner =
             new ArrayBlockingQueue<>(16);
 
     private final AtomicInteger numBlockingJobManagerRunners;
 
-    public TestingJobManagerRunnerFactory() {
-        this(0);
-    }
-
-    public TestingJobManagerRunnerFactory(int numBlockingJobManagerRunners) {
+    protected TestingJobManagerRunnerFactory(int numBlockingJobManagerRunners) {
         this.numBlockingJobManagerRunners = new AtomicInteger(numBlockingJobManagerRunners);
     }
 
-    @Override
-    public TestingJobManagerRunner createJobManagerRunner(
-            JobGraph jobGraph,
-            Configuration configuration,
-            RpcService rpcService,
-            HighAvailabilityServices highAvailabilityServices,
-            HeartbeatServices heartbeatServices,
-            JobManagerSharedServices jobManagerServices,
-            JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-            FatalErrorHandler fatalErrorHandler,
-            long initializationTimestamp)
-            throws Exception {
+    protected TestingJobManagerRunner offerTestingJobManagerRunner(JobID jobId) {
         final TestingJobManagerRunner testingJobManagerRunner =
-                createTestingJobManagerRunner(jobGraph);
+                createTestingJobManagerRunner(jobId);
         Preconditions.checkState(
                 createdJobManagerRunner.offer(testingJobManagerRunner),
                 "Unable to persist created the new runner.");
         return testingJobManagerRunner;
     }
 
-    @Nonnull
-    private TestingJobManagerRunner createTestingJobManagerRunner(JobGraph jobGraph) {
+    private TestingJobManagerRunner createTestingJobManagerRunner(JobID jobId) {
         final boolean blockingTermination = numBlockingJobManagerRunners.getAndDecrement() > 0;
         return TestingJobManagerRunner.newBuilder()
-                .setJobId(jobGraph.getJobID())
+                .setJobId(jobId)
                 .setBlockingTermination(blockingTermination)
                 .build();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobMasterServiceLeadershipRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobMasterServiceLeadershipRunnerFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * {@code TestingJobMasterServiceLeadershipRunnerFactory} implements {@code JobManagerRunnerFactory}
+ * providing a factory method usually used for {@link
+ * org.apache.flink.runtime.jobmaster.JobMasterServiceLeadershipRunner} creations.
+ */
+public class TestingJobMasterServiceLeadershipRunnerFactory extends TestingJobManagerRunnerFactory
+        implements JobManagerRunnerFactory {
+
+    public TestingJobMasterServiceLeadershipRunnerFactory() {
+        this(0);
+    }
+
+    public TestingJobMasterServiceLeadershipRunnerFactory(int numBlockingJobManagerRunners) {
+        super(numBlockingJobManagerRunners);
+    }
+
+    @Override
+    public TestingJobManagerRunner createJobManagerRunner(
+            JobGraph jobGraph,
+            Configuration configuration,
+            RpcService rpcService,
+            HighAvailabilityServices highAvailabilityServices,
+            HeartbeatServices heartbeatServices,
+            JobManagerSharedServices jobManagerServices,
+            JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+            FatalErrorHandler fatalErrorHandler,
+            long initializationTimestamp)
+            throws Exception {
+        return offerTestingJobManagerRunner(jobGraph.getJobID());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunnerTest.java
@@ -1,0 +1,589 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.TestingCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.TestingCheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.TestingCompletedCheckpointStore;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.dispatcher.UnavailableDispatcherOperationException;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
+import org.apache.flink.runtime.jobmaster.JobManagerRunnerResult;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code CheckpointResourcesCleanupRunnerTest} tests the {@link CheckpointResourcesCleanupRunner}
+ * implementation.
+ */
+public class CheckpointResourcesCleanupRunnerTest {
+
+    private static final ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+            BEFORE_START = ignored -> {};
+    private static final ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+            AFTER_START = CheckpointResourcesCleanupRunner::start;
+    private static final ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+            AFTER_CLOSE =
+                    runner -> {
+                        runner.start();
+                        runner.close();
+                    };
+
+    @Test
+    public void testIsInitializedBeforeStart() throws Exception {
+        testIsInitialized(BEFORE_START);
+    }
+
+    @Test
+    public void testIsInitializedAfterStart() throws Exception {
+        testIsInitialized(AFTER_START);
+    }
+
+    @Test
+    public void testIsInitializedAfterClose() throws Exception {
+        testIsInitialized(AFTER_CLOSE);
+    }
+
+    private static void testIsInitialized(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final CheckpointResourcesCleanupRunner testInstance = new TestInstanceBuilder().build();
+        preCheckLifecycleHandling.accept(testInstance);
+
+        assertThat(testInstance.isInitialized()).isTrue();
+    }
+
+    @Test
+    public void testCloseAsyncBeforeStart() {
+        final CheckpointResourcesCleanupRunner testInstance = new TestInstanceBuilder().build();
+        assertThat(testInstance.closeAsync()).isNotCompleted();
+    }
+
+    @Test
+    public void testSuccessfulCloseAsyncAfterStart() throws Exception {
+        final CompletableFuture<JobStatus> completedCheckpointStoreShutdownFuture =
+                new CompletableFuture<>();
+        final CompletableFuture<JobStatus> checkpointIdCounterShutdownFuture =
+                new CompletableFuture<>();
+
+        final HaltingCheckpointRecoveryFactory checkpointRecoveryFactory =
+                new HaltingCheckpointRecoveryFactory(
+                        completedCheckpointStoreShutdownFuture, checkpointIdCounterShutdownFuture);
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withCheckpointRecoveryFactory(checkpointRecoveryFactory)
+                        .withExecutor(ForkJoinPool.commonPool())
+                        .build();
+        testInstance.start();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore shouldn't have been shut down, yet.")
+                .isNotCompleted();
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter shouldn't have been shut down, yet.")
+                .isNotCompleted();
+
+        assertThat(testInstance.closeAsync())
+                .as(
+                        "closeAsync shouldn't have been completed, yet, since the shutdown of the components is not completed.")
+                .isNotCompleted();
+
+        checkpointRecoveryFactory.triggerCreation();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+
+        assertThat(testInstance.closeAsync()).succeedsWithin(Duration.ofMillis(100));
+    }
+
+    @Test
+    public void testCloseAsyncAfterStartAndErrorInCompletedCheckpointStoreShutdown()
+            throws Exception {
+        final CompletableFuture<JobStatus> checkpointIdCounterShutdownFuture =
+                new CompletableFuture<>();
+
+        final HaltingCheckpointRecoveryFactory checkpointRecoveryFactory =
+                new HaltingCheckpointRecoveryFactory(
+                        TestingCompletedCheckpointStore.builder()
+                                .withShutdownConsumer(
+                                        (ignoredJobStatus, ignoredCheckpointsCleaner) -> {
+                                            throw new RuntimeException(
+                                                    "Expected RuntimeException simulating an error during shutdown.");
+                                        })
+                                .build(),
+                        TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                                checkpointIdCounterShutdownFuture));
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withCheckpointRecoveryFactory(checkpointRecoveryFactory)
+                        .withExecutor(ForkJoinPool.commonPool())
+                        .build();
+        testInstance.start();
+
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter shouldn't have been shut down, yet.")
+                .isNotCompleted();
+
+        assertThat(testInstance.closeAsync())
+                .as(
+                        "closeAsync shouldn't have been completed, yet, since the shutdown of the components is not completed.")
+                .isNotCompleted();
+
+        checkpointRecoveryFactory.triggerCreation();
+
+        assertThat(checkpointIdCounterShutdownFuture)
+                .as("The CheckpointIDCounter should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+
+        assertThat(testInstance.closeAsync())
+                .failsWithin(Duration.ofMillis(100))
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testCloseAsyncAfterStartAndErrorInCheckpointIDCounterShutdown() throws Exception {
+        final CompletableFuture<JobStatus> completedCheckpointStoreShutdownFuture =
+                new CompletableFuture<>();
+
+        final HaltingCheckpointRecoveryFactory checkpointRecoveryFactory =
+                new HaltingCheckpointRecoveryFactory(
+                        TestingCompletedCheckpointStore
+                                .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                        completedCheckpointStoreShutdownFuture),
+                        TestingCheckpointIDCounter.builder()
+                                .withShutdownConsumer(
+                                        ignoredJobStatus -> {
+                                            throw new RuntimeException(
+                                                    "Expected RuntimeException simulating an error during shutdown.");
+                                        })
+                                .build());
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withCheckpointRecoveryFactory(checkpointRecoveryFactory)
+                        .withExecutor(ForkJoinPool.commonPool())
+                        .build();
+        testInstance.start();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore shouldn't have been shut down, yet.")
+                .isNotCompleted();
+
+        assertThat(testInstance.closeAsync())
+                .as(
+                        "closeAsync shouldn't have been completed, yet, since the shutdown of the components is not completed.")
+                .isNotCompleted();
+
+        checkpointRecoveryFactory.triggerCreation();
+
+        assertThat(completedCheckpointStoreShutdownFuture)
+                .as("The CompletedCheckpointStore should have been shut down properly.")
+                .succeedsWithin(Duration.ofMillis(100))
+                .isEqualTo(JobStatus.FINISHED);
+
+        assertThat(testInstance.closeAsync())
+                .failsWithin(Duration.ofMillis(100))
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testResultFutureWithSuccessBeforeStart() throws Exception {
+        testResultFutureWithSuccess(BEFORE_START);
+    }
+
+    @Test
+    public void testResultFutureWithSuccessAfterStart() throws Exception {
+        testResultFutureWithSuccess(AFTER_START);
+    }
+
+    @Test
+    public void testResultFutureWithSuccessAfterClose() throws Exception {
+        testResultFutureWithSuccess(AFTER_CLOSE);
+    }
+
+    private static void testResultFutureWithSuccess(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        testResultFuture(createDummySuccessJobResult(), preCheckLifecycleHandling);
+    }
+
+    @Test
+    public void testResultFutureWithErrorBeforeStart() throws Exception {
+        testResultFutureWithError(BEFORE_START);
+    }
+
+    @Test
+    public void testResultFutureWithErrorAfterStart() throws Exception {
+        testResultFutureWithError(AFTER_START);
+    }
+
+    @Test
+    public void testResultFutureWithErrorAfterClose() throws Exception {
+        testResultFutureWithError(AFTER_CLOSE);
+    }
+
+    private static void testResultFutureWithError(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final SerializedThrowable expectedError =
+                new SerializedThrowable(new Exception("Expected exception"));
+        final CompletableFuture<JobManagerRunnerResult> actualResult =
+                testResultFuture(
+                        createJobResultWithFailure(expectedError), preCheckLifecycleHandling);
+
+        assertThat(actualResult)
+                .succeedsWithin(Duration.ZERO)
+                .extracting(JobManagerRunnerResult::getExecutionGraphInfo)
+                .extracting(ExecutionGraphInfo::getArchivedExecutionGraph)
+                .extracting(AccessExecutionGraph::getFailureInfo)
+                .extracting(ErrorInfo::getException)
+                .isEqualTo(expectedError);
+    }
+
+    private static CompletableFuture<JobManagerRunnerResult> testResultFuture(
+            JobResult jobResult,
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder().withJobResult(jobResult).build();
+        preCheckLifecycleHandling.accept(testInstance);
+
+        assertThat(testInstance.getResultFuture())
+                .succeedsWithin(Duration.ZERO)
+                .extracting(JobManagerRunnerResult::isSuccess)
+                .isEqualTo(true);
+
+        return testInstance.getResultFuture();
+    }
+
+    @Test
+    public void testGetJobID() {
+        final JobID jobId = new JobID();
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withJobResult(createJobResult(jobId, ApplicationStatus.CANCELED))
+                        .build();
+        assertThat(testInstance.getJobID()).isEqualTo(jobId);
+    }
+
+    @Test
+    public void testGetJobMasterGatewayBeforeStart() throws Exception {
+        testGetJobMasterGateway(BEFORE_START);
+    }
+
+    @Test
+    public void testGetJobMasterGatewayAfterStart() throws Exception {
+        testGetJobMasterGateway(AFTER_START);
+    }
+
+    @Test
+    public void testGetJobMasterGatewayAfterClose() throws Exception {
+        testGetJobMasterGateway(AFTER_CLOSE);
+    }
+
+    private static void testGetJobMasterGateway(
+            ThrowingConsumer<CheckpointResourcesCleanupRunner, ? extends Exception>
+                    preCheckLifecycleHandling)
+            throws Exception {
+        final CheckpointResourcesCleanupRunner testInstance = new TestInstanceBuilder().build();
+        preCheckLifecycleHandling.accept(testInstance);
+
+        assertThat(testInstance.getJobMasterGateway())
+                .failsWithin(Duration.ZERO)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(UnavailableDispatcherOperationException.class);
+    }
+
+    @Test
+    public void testRequestJob_ExceptionHistory() {
+        testRequestJob(
+                createDummySuccessJobResult(),
+                System.currentTimeMillis(),
+                actualExecutionGraphInfo ->
+                        assertThat(actualExecutionGraphInfo)
+                                .extracting(ExecutionGraphInfo::getExceptionHistory)
+                                .asList()
+                                .isEmpty());
+    }
+
+    @Test
+    public void testRequestJob_JobName() {
+        testRequestJobExecutionGraph(
+                createDummySuccessJobResult(),
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getJobName)
+                                .isEqualTo("unknown"));
+    }
+
+    @Test
+    public void testRequestJob_JobId() {
+        final JobResult jobResult = createDummySuccessJobResult();
+        testRequestJobExecutionGraph(
+                jobResult,
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getJobID)
+                                .isEqualTo(jobResult.getJobId()));
+    }
+
+    @Test
+    public void testRequestJob_JobState() {
+        final JobResult jobResult = createDummySuccessJobResult();
+        testRequestJobExecutionGraph(
+                jobResult,
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getState)
+                                .isEqualTo(jobResult.getApplicationStatus().deriveJobStatus()));
+    }
+
+    @Test
+    public void testRequestJob_InitiatizationTimestamp() {
+        final long initializationTimestamp = System.currentTimeMillis();
+        testRequestJobExecutionGraph(
+                createDummySuccessJobResult(),
+                initializationTimestamp,
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph.getStatusTimestamp(JobStatus.INITIALIZING))
+                                .isEqualTo(initializationTimestamp));
+    }
+
+    @Test
+    public void testRequestJobWithFailure() {
+        final SerializedThrowable expectedError =
+                new SerializedThrowable(new Exception("Expected exception"));
+        final JobResult jobResult = createJobResultWithFailure(expectedError);
+        testRequestJobExecutionGraph(
+                jobResult,
+                System.currentTimeMillis(),
+                actualExecutionGraph ->
+                        assertThat(actualExecutionGraph)
+                                .extracting(AccessExecutionGraph::getFailureInfo)
+                                .extracting(ErrorInfo::getException)
+                                .isEqualTo(expectedError));
+    }
+
+    private static void testRequestJobExecutionGraph(
+            JobResult jobResult,
+            long initializationTimestamp,
+            ThrowingConsumer<AccessExecutionGraph, ? extends Exception> assertion) {
+        testRequestJob(
+                jobResult,
+                initializationTimestamp,
+                actualExecutionGraphInfo ->
+                        assertThat(actualExecutionGraphInfo)
+                                .extracting(ExecutionGraphInfo::getArchivedExecutionGraph)
+                                .satisfies(assertion::accept));
+    }
+
+    private static void testRequestJob(
+            JobResult jobResult,
+            long initializationTimestamp,
+            ThrowingConsumer<ExecutionGraphInfo, ? extends Exception> assertion) {
+        final CheckpointResourcesCleanupRunner testInstance =
+                new TestInstanceBuilder()
+                        .withJobResult(jobResult)
+                        .withInitializationTimestamp(initializationTimestamp)
+                        .build();
+
+        final CompletableFuture<ExecutionGraphInfo> response =
+                testInstance.requestJob(Time.milliseconds(0));
+        assertThat(response).succeedsWithin(Duration.ZERO).satisfies(assertion::accept);
+    }
+
+    private static JobResult createDummySuccessJobResult() {
+        return createJobResult(new JobID(), ApplicationStatus.SUCCEEDED);
+    }
+
+    private static JobResult createJobResultWithFailure(SerializedThrowable throwable) {
+        return new JobResult.Builder()
+                .jobId(new JobID())
+                .applicationStatus(ApplicationStatus.FAILED)
+                .serializedThrowable(throwable)
+                .netRuntime(1)
+                .build();
+    }
+
+    private static JobResult createJobResult(JobID jobId, ApplicationStatus applicationStatus) {
+        return new JobResult.Builder()
+                .jobId(jobId)
+                .applicationStatus(applicationStatus)
+                .netRuntime(1)
+                .build();
+    }
+
+    private static CheckpointRecoveryFactory createCheckpointRecoveryFactory() {
+        return new TestingCheckpointRecoveryFactory(
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                new CompletableFuture<>()),
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        new CompletableFuture<>()));
+    }
+
+    private static class TestInstanceBuilder {
+
+        private JobResult jobResult = createDummySuccessJobResult();
+        private CheckpointRecoveryFactory checkpointRecoveryFactory =
+                createCheckpointRecoveryFactory();
+        private CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
+        private SharedStateRegistryFactory sharedStateRegistryFactory =
+                SharedStateRegistry.DEFAULT_FACTORY;
+        private Executor executor = Executors.directExecutor();
+        private Configuration configuration = new Configuration();
+        private long initializationTimestamp = System.currentTimeMillis();
+
+        public TestInstanceBuilder withJobResult(JobResult jobResult) {
+            this.jobResult = jobResult;
+            return this;
+        }
+
+        public TestInstanceBuilder withCheckpointRecoveryFactory(
+                CheckpointRecoveryFactory checkpointRecoveryFactory) {
+            this.checkpointRecoveryFactory = checkpointRecoveryFactory;
+            return this;
+        }
+
+        public TestInstanceBuilder withCheckpointsCleaner(CheckpointsCleaner checkpointsCleaner) {
+            this.checkpointsCleaner = checkpointsCleaner;
+            return this;
+        }
+
+        public TestInstanceBuilder withSharedStateRegistryFactory(
+                SharedStateRegistryFactory sharedStateRegistryFactory) {
+            this.sharedStateRegistryFactory = sharedStateRegistryFactory;
+            return this;
+        }
+
+        public TestInstanceBuilder withExecutor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        public TestInstanceBuilder withConfiguration(Configuration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public TestInstanceBuilder withInitializationTimestamp(long initializationTimestamp) {
+            this.initializationTimestamp = initializationTimestamp;
+            return this;
+        }
+
+        public CheckpointResourcesCleanupRunner build() {
+            return new CheckpointResourcesCleanupRunner(
+                    jobResult,
+                    checkpointRecoveryFactory,
+                    checkpointsCleaner,
+                    sharedStateRegistryFactory,
+                    configuration,
+                    executor,
+                    initializationTimestamp);
+        }
+    }
+
+    private static class HaltingCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
+
+        private final CompletedCheckpointStore completedCheckpointStore;
+        private final CheckpointIDCounter checkpointIDCounter;
+
+        private final OneShotLatch creationLatch = new OneShotLatch();
+
+        public HaltingCheckpointRecoveryFactory(
+                CompletableFuture<JobStatus> completableCheckpointStoreShutDownFuture,
+                CompletableFuture<JobStatus> checkpointIDCounterShutDownFuture) {
+            this(
+                    TestingCompletedCheckpointStore
+                            .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                    completableCheckpointStoreShutDownFuture),
+                    TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                            checkpointIDCounterShutDownFuture));
+        }
+
+        public HaltingCheckpointRecoveryFactory(
+                CompletedCheckpointStore completedCheckpointStore,
+                CheckpointIDCounter checkpointIDCounter) {
+            this.completedCheckpointStore = Preconditions.checkNotNull(completedCheckpointStore);
+            this.checkpointIDCounter = Preconditions.checkNotNull(checkpointIDCounter);
+        }
+
+        @Override
+        public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
+                JobID jobId,
+                int maxNumberOfCheckpointsToRetain,
+                SharedStateRegistryFactory sharedStateRegistryFactory,
+                Executor ioExecutor)
+                throws Exception {
+            creationLatch.await();
+            return completedCheckpointStore;
+        }
+
+        @Override
+        public CheckpointIDCounter createCheckpointIDCounter(JobID jobId) throws Exception {
+            creationLatch.await();
+            return checkpointIDCounter;
+        }
+
+        public void triggerCreation() {
+            creationLatch.trigger();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingCleanupRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingCleanupRunnerFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.dispatcher.TestingJobManagerRunnerFactory;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
+
+import java.util.concurrent.Executor;
+
+/**
+ * {@code TestingCleanupRunnerFactory} implements {@link CleanupRunnerFactory} providing a factory
+ * method usually used for {@link CheckpointResourcesCleanupRunner} creations.
+ */
+public class TestingCleanupRunnerFactory extends TestingJobManagerRunnerFactory
+        implements CleanupRunnerFactory {
+
+    public TestingCleanupRunnerFactory() {
+        super(0);
+    }
+
+    @Override
+    public TestingJobManagerRunner create(
+            JobResult jobResult,
+            CheckpointRecoveryFactory checkpointRecoveryFactory,
+            Configuration configuration,
+            Executor cleanupExecutor) {
+        try {
+            return offerTestingJobManagerRunner(jobResult.getJobId());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Executor;
+
+/** {@code TestingResourceCleanerFactory} for adding custom {@link ResourceCleaner} creation. */
+public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
+
+    private final Collection<LocallyCleanableResource> locallyCleanableResources =
+            new ArrayList<>();
+    private final Collection<GloballyCleanableResource> globallyCleanableResources =
+            new ArrayList<>();
+
+    private final Executor cleanupExecutor;
+
+    public TestingResourceCleanerFactory() {
+        this(Executors.directExecutor());
+    }
+
+    private TestingResourceCleanerFactory(Executor cleanupExecutor) {
+        this.cleanupExecutor = cleanupExecutor;
+    }
+
+    public TestingResourceCleanerFactory withLocallyCleanableResource(
+            LocallyCleanableResource locallyCleanableResource) {
+        this.locallyCleanableResources.add(locallyCleanableResource);
+
+        return this;
+    }
+
+    public TestingResourceCleanerFactory withGloballyCleanableResource(
+            GloballyCleanableResource globallyCleanableResource) {
+        this.globallyCleanableResources.add(globallyCleanableResource);
+
+        return this;
+    }
+
+    @Override
+    public ResourceCleaner createLocalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return jobId -> {
+            mainThreadExecutor.assertRunningInMainThread();
+            Throwable t = null;
+            for (LocallyCleanableResource locallyCleanableResource : locallyCleanableResources) {
+                try {
+                    locallyCleanableResource.localCleanupAsync(jobId, cleanupExecutor).get();
+                } catch (Throwable throwable) {
+                    t = ExceptionUtils.firstOrSuppressed(throwable, t);
+                }
+            }
+
+            return t != null
+                    ? FutureUtils.completedExceptionally(t)
+                    : FutureUtils.completedVoidFuture();
+        };
+    }
+
+    @Override
+    public ResourceCleaner createGlobalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return jobId -> {
+            mainThreadExecutor.assertRunningInMainThread();
+            Throwable t = null;
+            for (GloballyCleanableResource globallyCleanableResource : globallyCleanableResources) {
+                try {
+                    globallyCleanableResource.globalCleanupAsync(jobId, cleanupExecutor).get();
+                } catch (Throwable throwable) {
+                    t = ExceptionUtils.firstOrSuppressed(throwable, t);
+                }
+            }
+
+            return t != null
+                    ? FutureUtils.completedExceptionally(t)
+                    : FutureUtils.completedVoidFuture();
+        };
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -152,7 +152,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
     @Test
     public void testCreateFromInitializingJobForSuspendedJob() {
         final ArchivedExecutionGraph suspendedExecutionGraph =
-                ArchivedExecutionGraph.createFromInitializingJob(
+                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                         new JobID(),
                         "TestJob",
                         JobStatus.SUSPENDED,
@@ -170,7 +170,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
                 CheckpointCoordinatorConfiguration.builder().build();
 
         final ArchivedExecutionGraph archivedGraph =
-                ArchivedExecutionGraph.createFromInitializingJob(
+                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                         new JobID(),
                         "TestJob",
                         JobStatus.INITIALIZING,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
@@ -52,7 +52,7 @@ public class DefaultJobMasterServiceProcessTest extends TestLogger {
     private static final Function<Throwable, ArchivedExecutionGraph>
             failedArchivedExecutionGraphFactory =
                     (throwable ->
-                            ArchivedExecutionGraph.createFromInitializingJob(
+                            ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                                     jobId, "test", JobStatus.FAILED, throwable, null, 1337));
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -259,7 +259,7 @@ public class JobMasterServiceLeadershipRunnerTest extends TestLogger {
     @Nonnull
     private ExecutionGraphInfo createFailedExecutionGraphInfo(FlinkException testException) {
         return new ExecutionGraphInfo(
-                ArchivedExecutionGraph.createFromInitializingJob(
+                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                         jobGraph.getJobID(),
                         jobGraph.getName(),
                         JobStatus.FAILED,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -69,7 +69,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 
         final ExecutionGraphInfo suspendedExecutionGraphInfo =
                 new ExecutionGraphInfo(
-                        ArchivedExecutionGraph.createFromInitializingJob(
+                        ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                                 jobId, "TestJob", JobStatus.SUSPENDED, null, null, 0L),
                         null);
         terminationFuture.whenComplete(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactory.java
@@ -64,7 +64,7 @@ public class TestingJobMasterServiceProcessFactory implements JobMasterServicePr
     @Override
     public ArchivedExecutionGraph createArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
-        return ArchivedExecutionGraph.createFromInitializingJob(
+        return ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                 jobId, jobName, jobStatus, cause, null, initializationTimestamp);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactoryOld.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactoryOld.java
@@ -72,7 +72,7 @@ public class TestingJobMasterServiceProcessFactoryOld implements JobMasterServic
     @Override
     public ArchivedExecutionGraph createArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
-        return ArchivedExecutionGraph.createFromInitializingJob(
+        return ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                 jobId, "test-job", jobStatus, cause, null, System.currentTimeMillis());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphInfoTest.java
@@ -36,7 +36,7 @@ public class ExecutionGraphInfoTest {
     @Test
     public void testExecutionGraphHistoryBeingDerivedFromFailedExecutionGraph() {
         final ArchivedExecutionGraph executionGraph =
-                ArchivedExecutionGraph.createFromInitializingJob(
+                ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                         new JobID(),
                         "test job name",
                         JobStatus.FAILED,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -807,7 +807,9 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final CompletableFuture<JobStatus> completedCheckpointStoreShutdownFuture =
                 new CompletableFuture<>();
         final CompletedCheckpointStore completedCheckpointStore =
-                new TestingCompletedCheckpointStore(completedCheckpointStoreShutdownFuture);
+                TestingCompletedCheckpointStore
+                        .createStoreWithShutdownCheckAndNoCompletedCheckpoints(
+                                completedCheckpointStoreShutdownFuture);
 
         final CompletableFuture<JobStatus> checkpointIdCounterShutdownFuture =
                 new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -814,7 +814,8 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final CompletableFuture<JobStatus> checkpointIdCounterShutdownFuture =
                 new CompletableFuture<>();
         final CheckpointIDCounter checkpointIdCounter =
-                new TestingCheckpointIDCounter(checkpointIdCounterShutdownFuture);
+                TestingCheckpointIDCounter.createStoreWithShutdownCheckAndNoStartAction(
+                        checkpointIdCounterShutdownFuture);
 
         final JobGraph jobGraph = createJobGraph();
         // checkpointing components are only created if checkpointing is enabled

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
@@ -117,7 +117,7 @@ public class CreatedTest extends TestLogger {
         @Override
         public ArchivedExecutionGraph getArchivedExecutionGraph(
                 JobStatus jobStatus, @Nullable Throwable cause) {
-            return ArchivedExecutionGraph.createFromInitializingJob(
+            return ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                     new JobID(), "testJob", jobStatus, cause, null, 0L);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -201,7 +201,7 @@ public class CreatingExecutionGraphTest extends TestLogger {
         @Override
         public ArchivedExecutionGraph getArchivedExecutionGraph(
                 JobStatus jobStatus, @Nullable Throwable cause) {
-            return ArchivedExecutionGraph.createFromInitializingJob(
+            return ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
                     new JobID(), "testJob", jobStatus, cause, null, 0L);
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This change introduces a `JobManagerRunner` implementation taking care of the cleanup of a otherwise finished job.

## Brief change log

* makes certain `Testing*` implementations more general to make testing of the new functionality easier
* Moves extraction of `state.checkpoints.num-retained` from `SchedulerUtils` into `DefaultCompletedCheckpointStoreUtils` (which is renamed into `CompletedCheckpointStoreUtils`) to align with the new use case for this functionality
* Makes `ApplicationStatus` <-> `JobStatus` mapping (partially) symmetric
* Introduces `CheckpointResourcesCleanupRunner` as a new `JobManagerRunner` implementation (+ correspondng factory class to support testing) and integrates it into the `Dispatcher`
* Reorganizes Dispatcher tests moving certain tests out of `DispatcherTest` into `DispatcherResourceCleanupTest`

## Verifying this change

This change added tests and can be verified as follows:

* ApplicationMode is tests in `ApplicationDispatcheerBootstrapITCase`
* General Dispatcher is tested in `DispatcherFailoverITCase`
* `DispatcherTest.testJobCleanupWithoutRecoveredJobGraph` testing that the job is cleaned up through a `CheckpointResourcesCleanupRunner` rather than initializing a new `JobMaster`
* `CheckpointResourcesCleanupRunnerTest` was added to cover new class `CheckpointResourcesCleanupRunner`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs
    * JavaDoc is provided
    * A `JobResultStore` section is added under `Deployment / High Availability`
    * `JobResultStore` is added to the glossary
