### PR TITLE
[FLINK-25432] Extends tests to cover missing test cases

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -191,7 +191,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
                         configuration, blobServer, fatalErrorHandler);
 
         jobManagerRunnerRegistry =
-                new DefaultJobManagerRunnerRegistry(16, this.getMainThreadExecutor());
+                new OnMainThreadJobManagerRunnerRegistry(
+                        new DefaultJobManagerRunnerRegistry(16), this.getMainThreadExecutor());
 
         this.historyServerArchivist = dispatcherServices.getHistoryServerArchivist();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.dispatcher;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -169,36 +170,103 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             DispatcherBootstrapFactory dispatcherBootstrapFactory,
             DispatcherServices dispatcherServices)
             throws Exception {
+        this(
+                rpcService,
+                fencingToken,
+                recoveredJobs,
+                recoveredDirtyJobs,
+                dispatcherBootstrapFactory,
+                dispatcherServices,
+                new DefaultJobManagerRunnerRegistry(16));
+    }
+
+    private Dispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> globallyTerminatedJobs,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            DispatcherServices dispatcherServices,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry)
+            throws Exception {
+        this(
+                rpcService,
+                fencingToken,
+                recoveredJobs,
+                globallyTerminatedJobs,
+                dispatcherServices.getConfiguration(),
+                dispatcherServices.getHighAvailabilityServices(),
+                dispatcherServices.getResourceManagerGatewayRetriever(),
+                dispatcherServices.getHeartbeatServices(),
+                dispatcherServices.getBlobServer(),
+                dispatcherServices.getFatalErrorHandler(),
+                dispatcherServices.getJobGraphWriter(),
+                dispatcherServices.getJobResultStore(),
+                dispatcherServices.getJobManagerMetricGroup(),
+                dispatcherServices.getMetricQueryServiceAddress(),
+                dispatcherServices.getIoExecutor(),
+                dispatcherServices.getHistoryServerArchivist(),
+                dispatcherServices.getArchivedExecutionGraphStore(),
+                dispatcherServices.getJobManagerRunnerFactory(),
+                dispatcherBootstrapFactory,
+                dispatcherServices.getOperationCaches(),
+                jobManagerRunnerRegistry,
+                new DispatcherResourceCleanerFactory(jobManagerRunnerRegistry, dispatcherServices));
+    }
+
+    @VisibleForTesting
+    protected Dispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> recoveredDirtyJobs,
+            Configuration configuration,
+            HighAvailabilityServices highAvailabilityServices,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            HeartbeatServices heartbeatServices,
+            BlobServer blobServer,
+            FatalErrorHandler fatalErrorHandler,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore,
+            JobManagerMetricGroup jobManagerMetricGroup,
+            @Nullable String metricServiceQueryAddress,
+            Executor ioExecutor,
+            HistoryServerArchivist historyServerArchivist,
+            ExecutionGraphInfoStore executionGraphInfoStore,
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            DispatcherOperationCaches dispatcherOperationCaches,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            ResourceCleanerFactory resourceCleanerFactory)
+            throws Exception {
         super(rpcService, RpcServiceUtils.createRandomName(DISPATCHER_NAME), fencingToken);
-        checkNotNull(dispatcherServices);
         assertRecoveredJobsAndDirtyJobResults(recoveredJobs, recoveredDirtyJobs);
 
-        this.configuration = dispatcherServices.getConfiguration();
-        this.highAvailabilityServices = dispatcherServices.getHighAvailabilityServices();
-        this.resourceManagerGatewayRetriever =
-                dispatcherServices.getResourceManagerGatewayRetriever();
-        this.heartbeatServices = dispatcherServices.getHeartbeatServices();
-        this.blobServer = dispatcherServices.getBlobServer();
-        this.fatalErrorHandler = dispatcherServices.getFatalErrorHandler();
-        this.jobGraphWriter = dispatcherServices.getJobGraphWriter();
-        this.jobResultStore = dispatcherServices.getJobResultStore();
-        this.jobManagerMetricGroup = dispatcherServices.getJobManagerMetricGroup();
-        this.metricServiceQueryAddress = dispatcherServices.getMetricQueryServiceAddress();
-        this.ioExecutor = dispatcherServices.getIoExecutor();
+        this.configuration = configuration;
+        this.highAvailabilityServices = highAvailabilityServices;
+        this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
+        this.heartbeatServices = heartbeatServices;
+        this.blobServer = blobServer;
+        this.fatalErrorHandler = fatalErrorHandler;
+        this.jobGraphWriter = jobGraphWriter;
+        this.jobResultStore = jobResultStore;
+        this.jobManagerMetricGroup = jobManagerMetricGroup;
+        this.metricServiceQueryAddress = metricServiceQueryAddress;
+        this.ioExecutor = ioExecutor;
 
         this.jobManagerSharedServices =
                 JobManagerSharedServices.fromConfiguration(
                         configuration, blobServer, fatalErrorHandler);
 
-        jobManagerRunnerRegistry =
+        this.jobManagerRunnerRegistry =
                 new OnMainThreadJobManagerRunnerRegistry(
-                        new DefaultJobManagerRunnerRegistry(16), this.getMainThreadExecutor());
+                        jobManagerRunnerRegistry, this.getMainThreadExecutor());
 
-        this.historyServerArchivist = dispatcherServices.getHistoryServerArchivist();
+        this.historyServerArchivist = historyServerArchivist;
 
-        this.executionGraphInfoStore = dispatcherServices.getArchivedExecutionGraphStore();
+        this.executionGraphInfoStore = executionGraphInfoStore;
 
-        this.jobManagerRunnerFactory = dispatcherServices.getJobManagerRunnerFactory();
+        this.jobManagerRunnerFactory = jobManagerRunnerFactory;
 
         this.jobManagerRunnerTerminationFutures = new HashMap<>(2);
 
@@ -214,12 +282,10 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
         this.dispatcherCachedOperationsHandler =
                 new DispatcherCachedOperationsHandler(
-                        dispatcherServices.getOperationCaches(),
+                        dispatcherOperationCaches,
                         this::triggerSavepointAndGetLocation,
                         this::stopWithSavepointAndGetLocation);
 
-        final ResourceCleanerFactory resourceCleanerFactory =
-                new DispatcherResourceCleanerFactory(jobManagerRunnerRegistry, dispatcherServices);
         this.localResourceCleaner =
                 resourceCleanerFactory.createLocalResourceCleaner(this.getMainThreadExecutor());
         this.globalResourceCleaner =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code OnMainThreadJobManagerRunnerRegistry} implements {@link JobManagerRunnerRegistry} guarding
+ * the passed {@code JobManagerRunnerRegistry} instance in a way that it only allows modifying
+ * methods to be executed on the component's main thread.
+ *
+ * @see ComponentMainThreadExecutor
+ */
+public class OnMainThreadJobManagerRunnerRegistry implements JobManagerRunnerRegistry {
+
+    private final JobManagerRunnerRegistry delegate;
+    private final ComponentMainThreadExecutor mainThreadExecutor;
+
+    public OnMainThreadJobManagerRunnerRegistry(
+            JobManagerRunnerRegistry delegate, ComponentMainThreadExecutor mainThreadExecutor) {
+        this.delegate = delegate;
+        this.mainThreadExecutor = mainThreadExecutor;
+    }
+
+    @Override
+    public boolean isRegistered(JobID jobId) {
+        return delegate.isRegistered(jobId);
+    }
+
+    @Override
+    public void register(JobManagerRunner jobManagerRunner) {
+        mainThreadExecutor.assertRunningInMainThread();
+        delegate.register(jobManagerRunner);
+    }
+
+    @Override
+    public JobManagerRunner get(JobID jobId) {
+        return delegate.get(jobId);
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public Set<JobID> getRunningJobIds() {
+        return delegate.getRunningJobIds();
+    }
+
+    @Override
+    public Collection<JobManagerRunner> getJobManagerRunners() {
+        return delegate.getJobManagerRunners();
+    }
+
+    @Override
+    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.globalCleanupAsync(jobId, executor);
+    }
+
+    @Override
+    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.localCleanupAsync(jobId, executor);
+    }
+
+    @Override
+    public JobManagerRunner unregister(JobID jobId) {
+        mainThreadExecutor.assertRunningInMainThread();
+        return delegate.unregister(jobId);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
@@ -62,7 +62,7 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
     }
 
     @VisibleForTesting
-    DispatcherResourceCleanerFactory(
+    public DispatcherResourceCleanerFactory(
             Executor cleanupExecutor,
             JobManagerRunnerRegistry jobManagerRunnerRegistry,
             JobGraphWriter jobGraphWriter,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -26,18 +26,10 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmanager.StandaloneJobGraphStore;
-import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -52,11 +44,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 
 /** Abstract test for the {@link Dispatcher} component. */
 public class AbstractDispatcherTest extends TestLogger {
@@ -116,6 +103,19 @@ public class AbstractDispatcherTest extends TestLogger {
                 new BlobServer(configuration, temporaryFolder.newFolder(), new VoidBlobStore());
     }
 
+    protected TestingDispatcher.Builder createTestingDispatcherBuilder() {
+        return TestingDispatcher.builder()
+                .withRpcService(rpcService)
+                .withConfiguration(configuration)
+                .withHeartbeatServices(heartbeatServices)
+                .withHighAvailabilityServices(haServices)
+                .withJobGraphWriter(haServices.getJobGraphStore())
+                .withJobResultStore(haServices.getJobResultStore())
+                .withJobManagerRunnerFactory(JobMasterServiceLeadershipRunnerFactory.INSTANCE)
+                .withFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
+                .withBlobServer(blobServer);
+    }
+
     @After
     public void tearDown() throws Exception {
         if (haServices != null) {
@@ -128,116 +128,5 @@ public class AbstractDispatcherTest extends TestLogger {
 
     protected BlobServer getBlobServer() {
         return blobServer;
-    }
-
-    /** A convenient builder for the {@link TestingDispatcher}. */
-    public class TestingDispatcherBuilder {
-
-        private Collection<JobGraph> initialJobGraphs = Collections.emptyList();
-
-        private Collection<JobResult> dirtyJobResults = Collections.emptyList();
-
-        private DispatcherBootstrapFactory dispatcherBootstrapFactory =
-                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
-
-        private HeartbeatServices heartbeatServices = AbstractDispatcherTest.this.heartbeatServices;
-
-        private HighAvailabilityServices haServices = AbstractDispatcherTest.this.haServices;
-
-        private JobManagerRunnerFactory jobManagerRunnerFactory =
-                JobMasterServiceLeadershipRunnerFactory.INSTANCE;
-
-        private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
-
-        private JobResultStore jobResultStore = new EmbeddedJobResultStore();
-
-        private FatalErrorHandler fatalErrorHandler =
-                testingFatalErrorHandlerResource.getFatalErrorHandler();
-
-        private HistoryServerArchivist historyServerArchivist = VoidHistoryServerArchivist.INSTANCE;
-
-        TestingDispatcherBuilder setHeartbeatServices(HeartbeatServices heartbeatServices) {
-            this.heartbeatServices = heartbeatServices;
-            return this;
-        }
-
-        TestingDispatcherBuilder setHaServices(HighAvailabilityServices haServices) {
-            this.haServices = haServices;
-            return this;
-        }
-
-        TestingDispatcherBuilder setInitialJobGraphs(Collection<JobGraph> initialJobGraphs) {
-            this.initialJobGraphs = initialJobGraphs;
-            return this;
-        }
-
-        TestingDispatcherBuilder setDirtyJobResults(Collection<JobResult> dirtyJobResults) {
-            this.dirtyJobResults = dirtyJobResults;
-            return this;
-        }
-
-        TestingDispatcherBuilder setDispatcherBootstrapFactory(
-                DispatcherBootstrapFactory dispatcherBootstrapFactory) {
-            this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobManagerRunnerFactory(
-                JobManagerRunnerFactory jobManagerRunnerFactory) {
-            this.jobManagerRunnerFactory = jobManagerRunnerFactory;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobGraphWriter(JobGraphWriter jobGraphWriter) {
-            this.jobGraphWriter = jobGraphWriter;
-            return this;
-        }
-
-        TestingDispatcherBuilder setJobResultStore(JobResultStore jobResultStore) {
-            this.jobResultStore = jobResultStore;
-            return this;
-        }
-
-        public TestingDispatcherBuilder setFatalErrorHandler(FatalErrorHandler fatalErrorHandler) {
-            this.fatalErrorHandler = fatalErrorHandler;
-            return this;
-        }
-
-        public TestingDispatcherBuilder setHistoryServerArchivist(
-                HistoryServerArchivist historyServerArchivist) {
-            this.historyServerArchivist = historyServerArchivist;
-            return this;
-        }
-
-        TestingDispatcher build() throws Exception {
-            TestingResourceManagerGateway resourceManagerGateway =
-                    new TestingResourceManagerGateway();
-
-            final MemoryExecutionGraphInfoStore executionGraphInfoStore =
-                    new MemoryExecutionGraphInfoStore();
-
-            return new TestingDispatcher(
-                    rpcService,
-                    DispatcherId.generate(),
-                    initialJobGraphs,
-                    dirtyJobResults,
-                    dispatcherBootstrapFactory,
-                    new DispatcherServices(
-                            configuration,
-                            haServices,
-                            () -> CompletableFuture.completedFuture(resourceManagerGateway),
-                            blobServer,
-                            heartbeatServices,
-                            executionGraphInfoStore,
-                            fatalErrorHandler,
-                            historyServerArchivist,
-                            null,
-                            new DispatcherOperationCaches(),
-                            UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
-                            jobGraphWriter,
-                            jobResultStore,
-                            jobManagerRunnerFactory,
-                            ForkJoinPool.commonPool()));
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.FlinkAssertions;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.util.FlinkException;
@@ -47,9 +46,7 @@ public class DefaultJobManagerRunnerRegistryTest {
 
     @BeforeEach
     public void setup() {
-        testInstance =
-                new DefaultJobManagerRunnerRegistry(
-                        4, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        testInstance = new DefaultJobManagerRunnerRegistry(4);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
@@ -241,14 +241,10 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
             }
         }
         final TestingDispatcher dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(
-                                JobMasterServiceLeadershipRunnerFactory.INSTANCE)
-                        .setJobGraphWriter(haServices.getJobGraphStore())
-                        .setJobResultStore(haServices.getJobResultStore())
-                        .setInitialJobGraphs(jobGraphs)
-                        .setDirtyJobResults(haServices.getJobResultStore().getDirtyResults())
-                        .setFatalErrorHandler(
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(jobGraphs)
+                        .withRecoveredDirtyJobs(haServices.getJobResultStore().getDirtyResults())
+                        .withFatalErrorHandler(
                                 fatalErrorHandler == null
                                         ? testingFatalErrorHandlerResource.getFatalErrorHandler()
                                         : fatalErrorHandler)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -41,15 +41,12 @@ import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
-import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -140,7 +137,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     private CompletableFuture<JobID> localCleanupFuture;
     private CompletableFuture<JobID> globalCleanupFuture;
     private CompletableFuture<JobID> cleanupJobHADataFuture;
-    private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
 
     @BeforeClass
     public static void setupClass() {
@@ -157,7 +153,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         highAvailabilityServices = new TestingHighAvailabilityServices();
         clearedJobLatch = new OneShotLatch();
         jobResultStore = new SingleJobResultStore(jobId, clearedJobLatch);
-        highAvailabilityServices.setJobResultStore(jobResultStore);
         cleanupJobHADataFuture = new CompletableFuture<>();
         highAvailabilityServices.setGlobalCleanupFuture(cleanupJobHADataFuture);
 
@@ -204,34 +199,16 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     }
 
     private void startDispatcher(JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
-        TestingResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
-        final HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
-        final MemoryExecutionGraphInfoStore archivedExecutionGraphStore =
-                new MemoryExecutionGraphInfoStore();
         dispatcher =
-                new TestingDispatcher(
-                        rpcService,
-                        DispatcherId.generate(),
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        (dispatcher, scheduledExecutor, errorHandler) ->
-                                new NoOpDispatcherBootstrap(),
-                        new DispatcherServices(
-                                configuration,
-                                highAvailabilityServices,
-                                () -> CompletableFuture.completedFuture(resourceManagerGateway),
-                                blobServer,
-                                heartbeatServices,
-                                archivedExecutionGraphStore,
-                                testingFatalErrorHandlerResource.getFatalErrorHandler(),
-                                VoidHistoryServerArchivist.INSTANCE,
-                                null,
-                                new DispatcherOperationCaches(),
-                                UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
-                                jobGraphWriter,
-                                jobResultStore,
-                                jobManagerRunnerFactory,
-                                ForkJoinPool.commonPool()));
+                TestingDispatcher.builder()
+                        .withRpcService(rpcService)
+                        .withHighAvailabilityServices(highAvailabilityServices)
+                        .withJobResultStore(jobResultStore)
+                        .withBlobServer(blobServer)
+                        .withFatalErrorHandler(
+                                testingFatalErrorHandlerResource.getFatalErrorHandler())
+                        .withJobManagerRunnerFactory(jobManagerRunnerFactory)
+                        .build();
 
         dispatcher.start();
 
@@ -242,6 +219,10 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     public void teardown() throws Exception {
         if (dispatcher != null) {
             dispatcher.close();
+        }
+
+        if (blobServer != null) {
+            blobServer.close();
         }
     }
 
@@ -665,7 +646,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                     throw new IOException("Expected IOException.");
                                 })
                         .build();
-        highAvailabilityServices.setJobResultStore(jobResultStore);
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 startDispatcherAndSubmitJob();
@@ -699,7 +679,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                     throw new IOException("Expected IOException.");
                                 })
                         .build();
-        highAvailabilityServices.setJobResultStore(jobResultStore);
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 startDispatcherAndSubmitJob();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.blob.TestingBlobStoreBuilder;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
-import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.dispatcher.cleanup.TestingResourceCleanerFactory;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -39,7 +38,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
-import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
@@ -74,10 +72,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -90,7 +86,6 @@ import static org.apache.flink.runtime.dispatcher.AbstractDispatcherTest.awaitSt
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Tests the resource cleanup by the {@link Dispatcher}. */
@@ -112,10 +107,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private JobGraph jobGraph;
 
-    private JobResultStore jobResultStore;
-
-    private OneShotLatch clearedJobLatch;
-
     private TestingDispatcher dispatcher;
 
     private DispatcherGateway dispatcherGateway;
@@ -135,9 +126,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
         jobId = jobGraph.getJobID();
 
-        clearedJobLatch = new OneShotLatch();
-        jobResultStore = new SingleJobResultStore(jobId, clearedJobLatch);
-
         globalCleanupFuture = new CompletableFuture<>();
         localCleanupFuture = new CompletableFuture<>();
 
@@ -154,46 +142,60 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private TestingJobManagerRunnerFactory startDispatcherAndSubmitJob(
             int numBlockingJobManagerRunners) throws Exception {
+        return startDispatcherAndSubmitJob(
+                createTestingDispatcherBuilder(), numBlockingJobManagerRunners);
+    }
+
+    private TestingJobManagerRunnerFactory startDispatcherAndSubmitJob(
+            TestingDispatcher.Builder dispatcherBuilder, int numBlockingJobManagerRunners)
+            throws Exception {
         final TestingJobManagerRunnerFactory testingJobManagerRunnerFactoryNG =
                 new TestingJobManagerRunnerFactory(numBlockingJobManagerRunners);
-        startDispatcher(testingJobManagerRunnerFactoryNG);
+        startDispatcher(dispatcherBuilder, testingJobManagerRunnerFactoryNG);
         submitJobAndWait();
 
         return testingJobManagerRunnerFactoryNG;
     }
 
     private void startDispatcher(JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
-        final JobManagerRunnerRegistry jobManagerRunnerRegistry =
-                new DefaultJobManagerRunnerRegistry(2);
-        dispatcher =
-                TestingDispatcher.builder()
-                        .withRpcService(rpcService)
-                        .withJobResultStore(jobResultStore)
-                        .withJobManagerRunnerRegistry(jobManagerRunnerRegistry)
-                        .withBlobServer(blobServer)
-                        .withFatalErrorHandler(
-                                testingFatalErrorHandlerResource.getFatalErrorHandler())
-                        .withResourceCleanerFactory(
-                                new TestingResourceCleanerFactory()
-                                        // JobManagerRunnerRegistry needs to be added explicitly
-                                        // because cleaning it will trigger the closeAsync latch
-                                        // provided by TestingJobManagerRunner
-                                        .withLocallyCleanableResource(jobManagerRunnerRegistry)
-                                        .withGloballyCleanableResource(
-                                                (jobId, executor) -> {
-                                                    globalCleanupFuture.complete(jobId);
-                                                    return FutureUtils.completedVoidFuture();
-                                                })
-                                        .withLocallyCleanableResource(
-                                                (jobId, executor) -> {
-                                                    localCleanupFuture.complete(jobId);
-                                                    return FutureUtils.completedVoidFuture();
-                                                }))
-                        .build();
+        startDispatcher(createTestingDispatcherBuilder(), jobManagerRunnerFactory);
+    }
+
+    private void startDispatcher(
+            TestingDispatcher.Builder dispatcherBuilder,
+            JobManagerRunnerFactory jobManagerRunnerFactory)
+            throws Exception {
+        dispatcher = dispatcherBuilder.withJobManagerRunnerFactory(jobManagerRunnerFactory).build();
 
         dispatcher.start();
 
         dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
+    }
+
+    private TestingDispatcher.Builder createTestingDispatcherBuilder() {
+        final JobManagerRunnerRegistry jobManagerRunnerRegistry =
+                new DefaultJobManagerRunnerRegistry(2);
+        return TestingDispatcher.builder()
+                .withRpcService(rpcService)
+                .withBlobServer(blobServer)
+                .withJobManagerRunnerRegistry(jobManagerRunnerRegistry)
+                .withFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
+                .withResourceCleanerFactory(
+                        new TestingResourceCleanerFactory()
+                                // JobManagerRunnerRegistry needs to be added explicitly
+                                // because cleaning it will trigger the closeAsync latch
+                                // provided by TestingJobManagerRunner
+                                .withLocallyCleanableResource(jobManagerRunnerRegistry)
+                                .withGloballyCleanableResource(
+                                        (jobId, ignoredExecutor) -> {
+                                            globalCleanupFuture.complete(jobId);
+                                            return FutureUtils.completedVoidFuture();
+                                        })
+                                .withLocallyCleanableResource(
+                                        (jobId, ignoredExecutor) -> {
+                                            localCleanupFuture.complete(jobId);
+                                            return FutureUtils.completedVoidFuture();
+                                        }));
     }
 
     @After
@@ -313,35 +315,86 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         assertGlobalCleanupTriggered(jobId);
     }
 
-    /**
-     * Tests that the {@link JobResultStore} entries are marked as clean after the job reached a
-     * terminal state.
-     */
     @Test
-    public void testJobResultStoreCleanup() throws Exception {
+    public void testJobBeingMarkedAsDirtyBeforeCleanup() throws Exception {
+        final OneShotLatch markAsDirtyLatch = new OneShotLatch();
+
+        final TestingDispatcher.Builder dispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .withJobResultStore(
+                                TestingJobResultStore.builder()
+                                        .withCreateDirtyResultConsumer(
+                                                ignoredJobResultEntry -> {
+                                                    try {
+                                                        markAsDirtyLatch.await();
+                                                    } catch (InterruptedException e) {
+                                                        throw new RuntimeException(e);
+                                                    }
+                                                })
+                                        .build());
+
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                startDispatcherAndSubmitJob();
+                startDispatcherAndSubmitJob(dispatcherBuilder, 0);
 
-        final JobResult jobResult =
-                TestingJobResultStore.createJobResult(jobId, ApplicationStatus.UNKNOWN);
+        finishJob(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
 
-        jobResultStore.createDirtyResult(new JobResultEntry(jobResult));
-        assertTrue(jobResultStore.hasJobResultEntry(jobId));
+        assertThatNoCleanupWasTriggered();
 
-        final TestingJobManagerRunner testingJobManagerRunner =
-                jobManagerRunnerFactory.takeCreatedJobManagerRunner();
-        testingJobManagerRunner.completeResultFuture(
-                new ExecutionGraphInfo(
-                        new ArchivedExecutionGraphBuilder()
-                                .setState(JobStatus.FINISHED)
-                                .setJobID(jobId)
-                                .build()));
+        markAsDirtyLatch.trigger();
 
-        // wait for the clearing
-        clearedJobLatch.await();
+        assertGlobalCleanupTriggered(jobId);
+    }
 
-        assertTrue(jobResultStore.hasJobResultEntry(jobId));
-        assertTrue(jobResultStore.getDirtyResults().isEmpty());
+    @Test
+    public void testJobBeingMarkedAsCleanAfterCleanup() throws Exception {
+        final CompletableFuture<JobID> markAsCleanFuture = new CompletableFuture<>();
+
+        final JobResultStore jobResultStore =
+                TestingJobResultStore.builder()
+                        .withMarkResultAsCleanConsumer(markAsCleanFuture::complete)
+                        .build();
+        final OneShotLatch localCleanupLatch = new OneShotLatch();
+        final OneShotLatch globalCleanupLatch = new OneShotLatch();
+        final TestingResourceCleanerFactory resourceCleanerFactory =
+                new TestingResourceCleanerFactory()
+                        .withLocallyCleanableResource(
+                                (ignoredJobId, ignoredExecutor) -> {
+                                    try {
+                                        localCleanupLatch.await();
+                                    } catch (InterruptedException e) {
+                                        throw new RuntimeException(e);
+                                    }
+
+                                    return FutureUtils.completedVoidFuture();
+                                })
+                        .withGloballyCleanableResource(
+                                (ignoredJobId, ignoredExecutor) -> {
+                                    try {
+                                        globalCleanupLatch.await();
+                                    } catch (InterruptedException e) {
+                                        throw new RuntimeException(e);
+                                    }
+
+                                    return FutureUtils.completedVoidFuture();
+                                });
+
+        final TestingDispatcher.Builder dispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .withJobResultStore(jobResultStore)
+                        .withResourceCleanerFactory(resourceCleanerFactory);
+
+        final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
+                startDispatcherAndSubmitJob(dispatcherBuilder, 0);
+
+        finishJob(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
+
+        assertThat(markAsCleanFuture.isDone(), is(false));
+
+        localCleanupLatch.trigger();
+        assertThat(markAsCleanFuture.isDone(), is(false));
+        globalCleanupLatch.trigger();
+
+        assertThat(markAsCleanFuture.get(), is(jobId));
     }
 
     /**
@@ -469,65 +522,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         dispatcherTerminationFuture.get();
     }
 
-    private static final class SingleJobResultStore implements JobResultStore {
-
-        private final JobID expectedJobId;
-        @Nullable private JobResultEntry actualJobResultEntry;
-        private boolean isDirty = true;
-
-        private final OneShotLatch clearedJobLatch;
-
-        private SingleJobResultStore(JobID expectedJobId, OneShotLatch clearedJobLatch) {
-            this.expectedJobId = expectedJobId;
-            this.clearedJobLatch = clearedJobLatch;
-        }
-
-        @Override
-        public void createDirtyResult(JobResultEntry jobResultEntry) throws IOException {
-            checkJobId(jobResultEntry.getJobId());
-            this.actualJobResultEntry = jobResultEntry;
-        }
-
-        private void checkJobId(JobID jobID) {
-            Preconditions.checkArgument(expectedJobId.equals(jobID));
-        }
-
-        @Override
-        public void markResultAsClean(JobID jobId) throws IOException {
-            checkJobId(jobId);
-            Preconditions.checkNotNull(actualJobResultEntry);
-            isDirty = false;
-            clearedJobLatch.trigger();
-        }
-
-        @Override
-        public boolean hasDirtyJobResultEntry(JobID jobId) throws IOException {
-            if (actualJobResultEntry == null) {
-                return false;
-            }
-
-            checkJobId(jobId);
-            return isDirty;
-        }
-
-        @Override
-        public boolean hasCleanJobResultEntry(JobID jobId) throws IOException {
-            if (actualJobResultEntry == null) {
-                return false;
-            }
-
-            checkJobId(jobId);
-            return !isDirty;
-        }
-
-        @Override
-        public Set<JobResult> getDirtyResults() throws IOException {
-            return actualJobResultEntry != null && isDirty
-                    ? Collections.singleton(actualJobResultEntry.getJobResult())
-                    : Collections.emptySet();
-        }
-    }
-
     private void assertLocalCleanupTriggered(JobID jobId)
             throws ExecutionException, InterruptedException, TimeoutException {
         assertThat(localCleanupFuture.get(100, TimeUnit.MILLISECONDS), equalTo(jobId));
@@ -542,7 +536,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     @Test
     public void testFatalErrorIfJobCannotBeMarkedDirtyInJobResultStore() throws Exception {
-        jobResultStore =
+        final JobResultStore jobResultStore =
                 TestingJobResultStore.builder()
                         .withCreateDirtyResultConsumer(
                                 jobResult -> {
@@ -551,7 +545,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                         .build();
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                startDispatcherAndSubmitJob();
+                startDispatcherAndSubmitJob(
+                        createTestingDispatcherBuilder().withJobResultStore(jobResultStore), 0);
 
         ArchivedExecutionGraph executionGraph =
                 new ArchivedExecutionGraphBuilder()
@@ -574,7 +569,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     @Test
     public void testErrorHandlingIfJobCannotBeMarkedAsCleanInJobResultStore() throws Exception {
         final CompletableFuture<JobResultEntry> dirtyJobFuture = new CompletableFuture<>();
-        jobResultStore =
+        final JobResultStore jobResultStore =
                 TestingJobResultStore.builder()
                         .withCreateDirtyResultConsumer(dirtyJobFuture::complete)
                         .withMarkResultAsCleanConsumer(
@@ -584,7 +579,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                         .build();
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                startDispatcherAndSubmitJob();
+                startDispatcherAndSubmitJob(
+                        createTestingDispatcherBuilder().withJobResultStore(jobResultStore), 0);
 
         ArchivedExecutionGraph executionGraph =
                 new ArchivedExecutionGraphBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -59,7 +59,6 @@ import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceProce
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
 import org.apache.flink.runtime.jobmaster.factories.TestingJobMasterServiceFactory;
-import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
@@ -89,7 +88,6 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
@@ -110,11 +108,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -127,12 +123,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
-import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -726,83 +720,6 @@ public class DispatcherTest extends AbstractDispatcherTest {
                         .build();
     }
 
-    /** Tests that a failing {@link JobManagerRunner} will be properly cleaned up. */
-    @Test
-    public void testFailingJobManagerRunnerCleanup() throws Exception {
-        final FlinkException testException = new FlinkException("Test exception.");
-        final ArrayBlockingQueue<Optional<Exception>> queue = new ArrayBlockingQueue<>(2);
-
-        final BlockingJobManagerRunnerFactory blockingJobManagerRunnerFactory =
-                new BlockingJobManagerRunnerFactory(
-                        () -> {
-                            final Optional<Exception> maybeException = queue.take();
-                            if (maybeException.isPresent()) {
-                                throw maybeException.get();
-                            }
-                        });
-
-        final BlockingQueue<String> cleanUpEvents = new LinkedBlockingQueue<>();
-
-        // Track cleanup - ha-services
-        final CompletableFuture<JobID> cleanupJobData = new CompletableFuture<>();
-        haServices.setGlobalCleanupFuture(cleanupJobData);
-        cleanupJobData.thenAccept(jobId -> cleanUpEvents.add(CLEANUP_HA_SERVICES));
-
-        // Track cleanup - job-graph
-        final TestingJobGraphStore jobGraphStore =
-                TestingJobGraphStore.newBuilder()
-                        .setLocalCleanupFunction(
-                                (jobId, executor) -> {
-                                    cleanUpEvents.add(CLEANUP_JOB_GRAPH_RELEASE);
-                                    return FutureUtils.completedVoidFuture();
-                                })
-                        .setGlobalCleanupFunction(
-                                (jobId, executor) -> {
-                                    cleanUpEvents.add(CLEANUP_JOB_GRAPH_REMOVE);
-                                    return FutureUtils.completedVoidFuture();
-                                })
-                        .build();
-        jobGraphStore.start(null);
-        haServices.setJobGraphStore(jobGraphStore);
-
-        // Track cleanup - job result store
-        haServices.setJobResultStore(
-                TestingJobResultStore.builder()
-                        .withMarkResultAsCleanConsumer(
-                                jobID -> cleanUpEvents.add(CLEANUP_JOB_RESULT_STORE))
-                        .build());
-
-        dispatcher =
-                createAndStartDispatcher(
-                        heartbeatServices, haServices, blockingJobManagerRunnerFactory);
-
-        final DispatcherGateway dispatcherGateway =
-                dispatcher.getSelfGateway(DispatcherGateway.class);
-
-        // submit and fail during job master runner construction
-        queue.offer(Optional.of(testException));
-        try {
-            dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
-            fail("A FlinkException is expected");
-        } catch (Throwable expectedException) {
-            assertThat(expectedException, containsCause(FlinkException.class));
-            assertThat(expectedException, containsMessage(testException.getMessage()));
-            // make sure we've cleaned up in correct order (including HA)
-            assertThat(
-                    new ArrayList<>(cleanUpEvents),
-                    containsInAnyOrder(CLEANUP_JOB_GRAPH_REMOVE, CLEANUP_HA_SERVICES));
-        }
-
-        // don't fail this time
-        queue.offer(Optional.empty());
-        // submit job again
-        dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
-        blockingJobManagerRunnerFactory.setJobStatus(JobStatus.RUNNING);
-
-        // Ensure job is running
-        awaitStatus(dispatcherGateway, jobId, JobStatus.RUNNING);
-    }
-
     @Test
     public void testPersistedJobGraphWhenDispatcherIsShutDown() throws Exception {
         final TestingJobGraphStore submittedJobGraphStore =
@@ -1361,70 +1278,6 @@ public class DispatcherTest extends AbstractDispatcherTest {
                 return future.whenComplete((r, t) -> super.closeAsync());
             }
             return super.closeAsync();
-        }
-    }
-
-    private static final class BlockingJobManagerRunnerFactory
-            extends TestingJobManagerRunnerFactory {
-
-        @Nonnull private final ThrowingRunnable<Exception> jobManagerRunnerCreationLatch;
-        private TestingJobManagerRunner testingRunner;
-
-        BlockingJobManagerRunnerFactory(
-                @Nonnull ThrowingRunnable<Exception> jobManagerRunnerCreationLatch) {
-            this.jobManagerRunnerCreationLatch = jobManagerRunnerCreationLatch;
-        }
-
-        @Override
-        public TestingJobManagerRunner createJobManagerRunner(
-                JobGraph jobGraph,
-                Configuration configuration,
-                RpcService rpcService,
-                HighAvailabilityServices highAvailabilityServices,
-                HeartbeatServices heartbeatServices,
-                JobManagerSharedServices jobManagerSharedServices,
-                JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-                FatalErrorHandler fatalErrorHandler,
-                long initializationTimestamp)
-                throws Exception {
-            jobManagerRunnerCreationLatch.run();
-
-            this.testingRunner =
-                    super.createJobManagerRunner(
-                            jobGraph,
-                            configuration,
-                            rpcService,
-                            highAvailabilityServices,
-                            heartbeatServices,
-                            jobManagerSharedServices,
-                            jobManagerJobMetricGroupFactory,
-                            fatalErrorHandler,
-                            initializationTimestamp);
-
-            TestingJobMasterGateway testingJobMasterGateway =
-                    new TestingJobMasterGatewayBuilder()
-                            .setRequestJobSupplier(
-                                    () ->
-                                            CompletableFuture.completedFuture(
-                                                    new ExecutionGraphInfo(
-                                                            ArchivedExecutionGraph
-                                                                    .createFromInitializingJob(
-                                                                            jobGraph.getJobID(),
-                                                                            jobGraph.getName(),
-                                                                            JobStatus.RUNNING,
-                                                                            null,
-                                                                            null,
-                                                                            1337))))
-                            .build();
-            testingRunner.completeJobMasterGatewayFuture(testingJobMasterGateway);
-            return testingRunner;
-        }
-
-        public void setJobStatus(JobStatus newStatus) {
-            Preconditions.checkState(
-                    testingRunner != null,
-                    "JobManagerRunner must be created before this method is available");
-            this.testingRunner.setJobStatus(newStatus);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -178,12 +178,12 @@ public class DispatcherTest extends AbstractDispatcherTest {
             JobManagerRunnerFactory jobManagerRunnerFactory)
             throws Exception {
         final TestingDispatcher dispatcher =
-                new TestingDispatcherBuilder()
-                        .setHaServices(haServices)
-                        .setHeartbeatServices(heartbeatServices)
-                        .setJobManagerRunnerFactory(jobManagerRunnerFactory)
-                        .setJobGraphWriter(haServices.getJobGraphStore())
-                        .setJobResultStore(haServices.getJobResultStore())
+                createTestingDispatcherBuilder()
+                        .withHighAvailabilityServices(haServices)
+                        .withHeartbeatServices(heartbeatServices)
+                        .withJobManagerRunnerFactory(jobManagerRunnerFactory)
+                        .withJobGraphWriter(haServices.getJobGraphStore())
+                        .withJobResultStore(haServices.getJobResultStore())
                         .build();
         dispatcher.start();
         return dispatcher;
@@ -246,11 +246,11 @@ public class DispatcherTest extends AbstractDispatcherTest {
     @Test
     public void testDuplicateJobSubmissionWithRunningJobId() throws Exception {
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(
+                createTestingDispatcherBuilder()
+                        .withJobManagerRunnerFactory(
                                 new ExpectedJobIdJobManagerRunnerFactory(
                                         jobId, createdJobManagerRunnerLatch))
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
+                        .withRecoveredJobs(Collections.singleton(jobGraph))
                         .build();
         dispatcher.start();
         final DispatcherGateway dispatcherGateway =
@@ -474,11 +474,11 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final CompletableFuture<JobManagerRunnerResult> jobTerminationFuture =
                 new CompletableFuture<>();
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(
+                createTestingDispatcherBuilder()
+                        .withJobManagerRunnerFactory(
                                 new FinishingJobManagerRunnerFactory(
                                         jobTerminationFuture, () -> {}))
-                        .setHistoryServerArchivist(
+                        .withHistoryServerArchivist(
                                 executionGraphInfo -> {
                                     archiveAttemptFuture.complete(null);
                                     return CompletableFuture.completedFuture(null);
@@ -675,10 +675,9 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 new TestingJobManagerRunnerFactory();
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setJobManagerRunnerFactory(jobManagerRunnerFactory)
-                        .setInitialJobGraphs(
-                                Collections.singleton(JobGraphTestUtils.emptyJobGraph()))
+                createTestingDispatcherBuilder()
+                        .withJobManagerRunnerFactory(jobManagerRunnerFactory)
+                        .withRecoveredJobs(Collections.singleton(JobGraphTestUtils.emptyJobGraph()))
                         .build();
 
         dispatcher.start();
@@ -721,9 +720,9 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final JobResult jobResult =
                 TestingJobResultStore.createSuccessfulJobResult(jobGraph.getJobID());
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
-                        .setDirtyJobResults(Collections.singleton(jobResult))
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(Collections.singleton(jobGraph))
+                        .withRecoveredDirtyJobs(Collections.singleton(jobResult))
                         .build();
     }
 
@@ -812,7 +811,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
         haServices.setJobGraphStore(submittedJobGraphStore);
 
         dispatcher =
-                new TestingDispatcherBuilder().setJobGraphWriter(submittedJobGraphStore).build();
+                createTestingDispatcherBuilder().withJobGraphWriter(submittedJobGraphStore).build();
 
         dispatcher.start();
 
@@ -930,9 +929,9 @@ public class DispatcherTest extends AbstractDispatcherTest {
         testingJobGraphStore.start(null);
 
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(jobGraph))
-                        .setJobGraphWriter(testingJobGraphStore)
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(Collections.singleton(jobGraph))
+                        .withJobGraphWriter(testingJobGraphStore)
                         .build();
         dispatcher.start();
 
@@ -1110,8 +1109,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final PermanentBlobKey blobKey2 = blobServer.putPermanent(jobId2, fileContent);
 
         dispatcher =
-                new TestingDispatcherBuilder()
-                        .setInitialJobGraphs(Collections.singleton(new JobGraph(jobId1, "foobar")))
+                createTestingDispatcherBuilder()
+                        .withRecoveredJobs(Collections.singleton(new JobGraph(jobId1, "foobar")))
                         .build();
 
         Assertions.assertThat(blobServer.getFile(jobId1, blobKey1)).hasBinaryContent(fileContent);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -20,16 +20,39 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
+import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.JobResultStore;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedJobResultStore;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 /** {@link Dispatcher} implementation used for testing purposes. */
@@ -52,6 +75,57 @@ class TestingDispatcher extends Dispatcher {
                 recoveredDirtyJobResults,
                 dispatcherBootstrapFactory,
                 dispatcherServices);
+
+        this.startFuture = new CompletableFuture<>();
+    }
+
+    private TestingDispatcher(
+            RpcService rpcService,
+            DispatcherId fencingToken,
+            Collection<JobGraph> recoveredJobs,
+            Collection<JobResult> recoveredDirtyJobs,
+            Configuration configuration,
+            HighAvailabilityServices highAvailabilityServices,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            HeartbeatServices heartbeatServices,
+            BlobServer blobServer,
+            FatalErrorHandler fatalErrorHandler,
+            JobGraphWriter jobGraphWriter,
+            JobResultStore jobResultStore,
+            JobManagerMetricGroup jobManagerMetricGroup,
+            @Nullable String metricServiceQueryAddress,
+            Executor ioExecutor,
+            HistoryServerArchivist historyServerArchivist,
+            ExecutionGraphInfoStore executionGraphInfoStore,
+            JobManagerRunnerFactory jobManagerRunnerFactory,
+            DispatcherBootstrapFactory dispatcherBootstrapFactory,
+            DispatcherOperationCaches dispatcherOperationCaches,
+            JobManagerRunnerRegistry jobManagerRunnerRegistry,
+            ResourceCleanerFactory resourceCleanerFactory)
+            throws Exception {
+        super(
+                rpcService,
+                fencingToken,
+                recoveredJobs,
+                recoveredDirtyJobs,
+                configuration,
+                highAvailabilityServices,
+                resourceManagerGatewayRetriever,
+                heartbeatServices,
+                blobServer,
+                fatalErrorHandler,
+                jobGraphWriter,
+                jobResultStore,
+                jobManagerMetricGroup,
+                metricServiceQueryAddress,
+                ioExecutor,
+                historyServerArchivist,
+                executionGraphInfoStore,
+                jobManagerRunnerFactory,
+                dispatcherBootstrapFactory,
+                dispatcherOperationCaches,
+                jobManagerRunnerRegistry,
+                resourceCleanerFactory);
 
         this.startFuture = new CompletableFuture<>();
     }
@@ -90,5 +164,213 @@ class TestingDispatcher extends Dispatcher {
 
     void waitUntilStarted() {
         startFuture.join();
+    }
+
+    public static TestingDispatcher.Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private RpcService rpcService = new TestingRpcService();
+        private DispatcherId fencingToken = DispatcherId.generate();
+        private Collection<JobGraph> recoveredJobs = Collections.emptyList();
+        private Collection<JobResult> recoveredDirtyJobs = Collections.emptyList();
+        private HighAvailabilityServices highAvailabilityServices =
+                new TestingHighAvailabilityServices();
+
+        private TestingResourceManagerGateway resourceManagerGateway =
+                new TestingResourceManagerGateway();
+        private GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever =
+                () -> CompletableFuture.completedFuture(resourceManagerGateway);
+        private HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
+
+        private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
+        private JobResultStore jobResultStore = new EmbeddedJobResultStore();
+
+        private Configuration configuration = new Configuration();
+
+        // even-though it's labeled as @Nullable, it's a mandatory field that needs to be set before
+        // building the Dispatcher instance
+        @Nullable private BlobServer blobServer = null;
+        private FatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+        private JobManagerMetricGroup jobManagerMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup();
+        @Nullable private String metricServiceQueryAddress = null;
+        private Executor ioExecutor = ForkJoinPool.commonPool();
+        private HistoryServerArchivist historyServerArchivist = VoidHistoryServerArchivist.INSTANCE;
+        private ExecutionGraphInfoStore executionGraphInfoStore =
+                new MemoryExecutionGraphInfoStore();
+        private JobManagerRunnerFactory jobManagerRunnerFactory =
+                new TestingJobManagerRunnerFactory(0);
+        private DispatcherBootstrapFactory dispatcherBootstrapFactory =
+                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
+        private DispatcherOperationCaches dispatcherOperationCaches =
+                new DispatcherOperationCaches();
+        private JobManagerRunnerRegistry jobManagerRunnerRegistry =
+                new DefaultJobManagerRunnerRegistry(1);
+        @Nullable private ResourceCleanerFactory resourceCleanerFactory;
+
+        public Builder withRpcService(RpcService rpcService) {
+            this.rpcService = rpcService;
+            return this;
+        }
+
+        public Builder withFencingToken(DispatcherId fencingToken) {
+            this.fencingToken = fencingToken;
+            return this;
+        }
+
+        public Builder withRecoveredJobs(Collection<JobGraph> recoveredJobs) {
+            this.recoveredJobs = recoveredJobs;
+            return this;
+        }
+
+        public Builder withRecoveredDirtyJobs(Collection<JobResult> recoveredDirtyJobs) {
+            this.recoveredDirtyJobs = recoveredDirtyJobs;
+            return this;
+        }
+
+        public Builder withHighAvailabilityServices(
+                HighAvailabilityServices highAvailabilityServices) {
+            this.highAvailabilityServices = highAvailabilityServices;
+            return this;
+        }
+
+        public Builder withResourceManagerGateway(
+                TestingResourceManagerGateway resourceManagerGateway) {
+            this.resourceManagerGateway = resourceManagerGateway;
+            return this;
+        }
+
+        public Builder withResourceManagerGatewayRetriever(
+                GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) {
+            this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
+            return this;
+        }
+
+        public Builder withHeartbeatServices(HeartbeatServices heartbeatServices) {
+            this.heartbeatServices = heartbeatServices;
+            return this;
+        }
+
+        public Builder withJobGraphWriter(JobGraphWriter jobGraphWriter) {
+            this.jobGraphWriter = jobGraphWriter;
+            return this;
+        }
+
+        public Builder withJobResultStore(JobResultStore jobResultStore) {
+            this.jobResultStore = jobResultStore;
+            return this;
+        }
+
+        public Builder withConfiguration(Configuration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public Builder withBlobServer(BlobServer blobServer) {
+            this.blobServer = blobServer;
+            return this;
+        }
+
+        public Builder withFatalErrorHandler(FatalErrorHandler fatalErrorHandler) {
+            this.fatalErrorHandler = fatalErrorHandler;
+            return this;
+        }
+
+        public Builder withJobManagerMetricGroup(JobManagerMetricGroup jobManagerMetricGroup) {
+            this.jobManagerMetricGroup = jobManagerMetricGroup;
+            return this;
+        }
+
+        public Builder withMetricServiceQueryAddress(@Nullable String metricServiceQueryAddress) {
+            this.metricServiceQueryAddress = metricServiceQueryAddress;
+            return this;
+        }
+
+        public Builder withIoExecutor(Executor ioExecutor) {
+            this.ioExecutor = ioExecutor;
+            return this;
+        }
+
+        public Builder withHistoryServerArchivist(HistoryServerArchivist historyServerArchivist) {
+            this.historyServerArchivist = historyServerArchivist;
+            return this;
+        }
+
+        public Builder withExecutionGraphInfoStore(
+                ExecutionGraphInfoStore executionGraphInfoStore) {
+            this.executionGraphInfoStore = executionGraphInfoStore;
+            return this;
+        }
+
+        public Builder withJobManagerRunnerFactory(
+                JobManagerRunnerFactory jobManagerRunnerFactory) {
+            this.jobManagerRunnerFactory = jobManagerRunnerFactory;
+            return this;
+        }
+
+        public Builder withDispatcherBootstrapFactory(
+                DispatcherBootstrapFactory dispatcherBootstrapFactory) {
+            this.dispatcherBootstrapFactory = dispatcherBootstrapFactory;
+            return this;
+        }
+
+        public Builder withDispatcherOperationCaches(
+                DispatcherOperationCaches dispatcherOperationCaches) {
+            this.dispatcherOperationCaches = dispatcherOperationCaches;
+            return this;
+        }
+
+        public Builder withJobManagerRunnerRegistry(
+                JobManagerRunnerRegistry jobManagerRunnerRegistry) {
+            this.jobManagerRunnerRegistry = jobManagerRunnerRegistry;
+            return this;
+        }
+
+        public Builder withResourceCleanerFactory(ResourceCleanerFactory resourceCleanerFactory) {
+            this.resourceCleanerFactory = resourceCleanerFactory;
+            return this;
+        }
+
+        private ResourceCleanerFactory createDefaultResourceCleanerFactory() {
+            return new DispatcherResourceCleanerFactory(
+                    ioExecutor,
+                    jobManagerRunnerRegistry,
+                    jobGraphWriter,
+                    blobServer,
+                    highAvailabilityServices,
+                    jobManagerMetricGroup);
+        }
+
+        public TestingDispatcher build() throws Exception {
+            return new TestingDispatcher(
+                    rpcService,
+                    fencingToken,
+                    recoveredJobs,
+                    recoveredDirtyJobs,
+                    configuration,
+                    highAvailabilityServices,
+                    resourceManagerGatewayRetriever,
+                    heartbeatServices,
+                    Preconditions.checkNotNull(
+                            blobServer,
+                            "No BlobServer is specified for building the TestingDispatcher"),
+                    fatalErrorHandler,
+                    jobGraphWriter,
+                    jobResultStore,
+                    jobManagerMetricGroup,
+                    metricServiceQueryAddress,
+                    ioExecutor,
+                    historyServerArchivist,
+                    executionGraphInfoStore,
+                    jobManagerRunnerFactory,
+                    dispatcherBootstrapFactory,
+                    dispatcherOperationCaches,
+                    jobManagerRunnerRegistry,
+                    resourceCleanerFactory != null
+                            ? resourceCleanerFactory
+                            : createDefaultResourceCleanerFactory());
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Executor;
+
+/** {@code TestingResourceCleanerFactory} for adding custom {@link ResourceCleaner} creation. */
+public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
+
+    private final Collection<LocallyCleanableResource> locallyCleanableResources =
+            new ArrayList<>();
+    private final Collection<GloballyCleanableResource> globallyCleanableResources =
+            new ArrayList<>();
+
+    private final Executor cleanupExecutor;
+
+    public TestingResourceCleanerFactory() {
+        this(Executors.directExecutor());
+    }
+
+    private TestingResourceCleanerFactory(Executor cleanupExecutor) {
+        this.cleanupExecutor = cleanupExecutor;
+    }
+
+    public TestingResourceCleanerFactory withLocallyCleanableResource(
+            LocallyCleanableResource locallyCleanableResource) {
+        this.locallyCleanableResources.add(locallyCleanableResource);
+
+        return this;
+    }
+
+    public TestingResourceCleanerFactory withGloballyCleanableResource(
+            GloballyCleanableResource globallyCleanableResource) {
+        this.globallyCleanableResources.add(globallyCleanableResource);
+
+        return this;
+    }
+
+    @Override
+    public ResourceCleaner createLocalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return jobId -> {
+            mainThreadExecutor.assertRunningInMainThread();
+            Throwable t = null;
+            for (LocallyCleanableResource locallyCleanableResource : locallyCleanableResources) {
+                try {
+                    locallyCleanableResource.localCleanupAsync(jobId, cleanupExecutor).get();
+                } catch (Throwable throwable) {
+                    t = ExceptionUtils.firstOrSuppressed(throwable, t);
+                }
+            }
+
+            return t != null
+                    ? FutureUtils.completedExceptionally(t)
+                    : FutureUtils.completedVoidFuture();
+        };
+    }
+
+    @Override
+    public ResourceCleaner createGlobalResourceCleaner(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return jobId -> {
+            mainThreadExecutor.assertRunningInMainThread();
+            Throwable t = null;
+            for (GloballyCleanableResource globallyCleanableResource : globallyCleanableResources) {
+                try {
+                    globallyCleanableResource.globalCleanupAsync(jobId, cleanupExecutor).get();
+                } catch (Throwable throwable) {
+                    t = ExceptionUtils.firstOrSuppressed(throwable, t);
+                }
+            }
+
+            return t != null
+                    ? FutureUtils.completedExceptionally(t)
+                    : FutureUtils.completedVoidFuture();
+        };
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Refactored the tests around cleanup collecting cleanup-relevant tests in `DispatcherResourceCleanupTest`

## Brief change log

* Makes `BlobServerClenupTest` based on JUnit5 and AssertJ and adds cleanup-related tests
* `DispatcherResourceCleanupTest` is refactored to only rely on the cleanup without testing the downstream CleanableResources. Testing that the right components are cleaned is tested in `DispatcherResourceCleanerFactoryTest`.  The actual cleanup for each component is then tested in the corresponding component tests.
* Additionally, I added test cases in `DispatcherResourceCleanerFactoryTest` for verifying that the `JobResult` is marked as dirty before the cleanup and clean after the cleanup

## Verifying this change

The PR itself is just tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
