### PR TITLE
[FLINK-31782][runtime] Makes DefaultLeaderElectionService implement MultipleComponentLeaderElectionDriver.Listener

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -210,7 +211,7 @@ public class KubernetesMultipleComponentLeaderElectionDriver
     private class LeaderCallbackHandlerImpl extends KubernetesLeaderElector.LeaderCallbackHandler {
         @Override
         public void isLeader() {
-            leaderElectionListener.isLeader();
+            leaderElectionListener.isLeader(UUID.randomUUID());
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -46,7 +47,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>{@code DefaultLeaderElectionService} handles a single {@link LeaderContender}.
  */
 public class DefaultLeaderElectionService extends AbstractLeaderElectionService
-        implements LeaderElectionEventHandler, AutoCloseable {
+        implements LeaderElectionEventHandler,
+                MultipleComponentLeaderElectionDriver.Listener,
+                AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultLeaderElectionService.class);
 
@@ -476,6 +479,44 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
                 leaderContender.handleError(new LeaderElectionException(t));
             }
         }
+    }
+
+    @Override
+    public void isLeader(UUID newLeaderSessionID) {
+        onGrantLeadership(newLeaderSessionID);
+    }
+
+    @Override
+    public void notLeader() {
+        onRevokeLeadership();
+    }
+
+    @Override
+    public void notifyLeaderInformationChange(
+            String contenderID, LeaderInformation leaderInformation) {
+        if (contenderID.equals(this.contenderID)) {
+            onLeaderInformationChange(leaderInformation);
+        }
+    }
+
+    @Override
+    public void notifyAllKnownLeaderInformation(
+            Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds) {
+        final long matchingContenderIDEntryCount =
+                leaderInformationWithComponentIds.stream()
+                        .filter(entry -> entry.getComponentId().equals(contenderID))
+                        .map(
+                                leaderInformationWithComponentId -> {
+                                    onLeaderInformationChange(
+                                            leaderInformationWithComponentId
+                                                    .getLeaderInformation());
+                                    return null;
+                                })
+                        .count();
+
+        Preconditions.checkArgument(
+                matchingContenderIDEntryCount < 2,
+                "There shouldn't be more than one LeaderInformation per contenderID.");
     }
 
     private class LeaderElectionFatalErrorHandler implements FatalErrorHandler {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -185,8 +185,7 @@ public class DefaultMultipleComponentLeaderElectionService
     }
 
     @Override
-    public void isLeader() {
-        final UUID newLeaderSessionId = UUID.randomUUID();
+    public void isLeader(UUID newLeaderSessionID) {
         synchronized (lock) {
             if (!running) {
                 return;
@@ -195,11 +194,11 @@ public class DefaultMultipleComponentLeaderElectionService
             Preconditions.checkState(
                     currentLeaderSessionId == null,
                     "notLeader() wasn't called by the LeaderElection backend before assigning leadership to this LeaderElectionService.");
-            currentLeaderSessionId = newLeaderSessionId;
+            currentLeaderSessionId = newLeaderSessionID;
 
             forEachLeaderElectionEventHandler(
                     leaderElectionEventHandler ->
-                            leaderElectionEventHandler.onGrantLeadership(newLeaderSessionId));
+                            leaderElectionEventHandler.onGrantLeadership(newLeaderSessionID));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.leaderelection;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * A leader election driver that allows to write {@link LeaderInformation} for multiple components.
@@ -62,8 +63,11 @@ public interface MultipleComponentLeaderElectionDriver {
      */
     interface Listener {
 
-        /** Callback that is called once the driver obtains the leadership. */
-        void isLeader();
+        /**
+         * Callback that is called once the driver obtains the leadership with the given {@code
+         * leaderSessionID}.
+         */
+        void isLeader(UUID leaderSessionID);
 
         /** Callback that is called once the driver loses the leadership. */
         void notLeader();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriver.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /** ZooKeeper based {@link MultipleComponentLeaderElectionDriver} implementation. */
@@ -184,7 +185,7 @@ public class ZooKeeperMultipleComponentLeaderElectionDriver
     @Override
     public void isLeader() {
         LOG.debug("{} obtained the leadership.", this);
-        leaderElectionListener.isLeader();
+        leaderElectionListener.isLeader(UUID.randomUUID());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
@@ -66,7 +66,7 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                 counter++;
             }
 
-            leaderElectionDriver.grantLeadership();
+            leaderElectionDriver.grantLeadership(UUID.randomUUID());
 
             for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
                 assertThat(eventListener.hasLeadership()).isTrue();
@@ -107,7 +107,7 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                 counter++;
             }
 
-            leaderElectionDriver.grantLeadership();
+            leaderElectionDriver.grantLeadership(UUID.randomUUID());
             leaderElectionDriver.revokeLeadership();
 
             for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
@@ -134,7 +134,7 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                     componentId, leaderElectionEventHandler);
             leaderElectionService.unregisterLeaderElectionEventHandler(componentId);
 
-            leaderElectionDriver.grantLeadership();
+            leaderElectionDriver.grantLeadership(UUID.randomUUID());
 
             assertThat(leaderElectionEventHandler.hasLeadership()).isFalse();
         } finally {
@@ -150,7 +150,7 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                 createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
 
         try {
-            leaderElectionDriver.grantLeadership();
+            leaderElectionDriver.grantLeadership(UUID.randomUUID());
 
             final SimpleTestingLeaderElectionEventListener leaderElectionEventHandler =
                     new SimpleTestingLeaderElectionEventListener();
@@ -186,7 +186,7 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                     preLeadershipGrantedComponent.getComponentId(),
                     preLeadershipGrantedComponent.getLeaderElectionEventListener());
 
-            leaderElectionDriver.grantLeadership();
+            leaderElectionDriver.grantLeadership(UUID.randomUUID());
 
             leaderElectionService.registerLeaderElectionEventHandler(
                     postLeadershipGrantedComponent.getComponentId(),
@@ -216,7 +216,7 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                 createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
 
         try {
-            leaderElectionDriver.grantLeadership();
+            leaderElectionDriver.grantLeadership(UUID.randomUUID());
 
             final Collection<Component> knownLeaderInformation = createComponents(3);
             final Collection<Component> unknownLeaderInformation = createComponents(2);
@@ -259,7 +259,8 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                                 leaderElectionDriver),
                         java.util.concurrent.Executors.newSingleThreadScheduledExecutor());
         try {
-            leaderElectionDriver.grantLeadership();
+            final UUID leaderSessionID = UUID.randomUUID();
+            leaderElectionDriver.grantLeadership(leaderSessionID);
 
             final String knownLeaderInformationComponent = "knownLeaderInformationComponent";
             final BlockingLeaderElectionEventHandler knownLeaderElectionEventHandler =
@@ -276,7 +277,7 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
                     Collections.singleton(
                             LeaderInformationWithComponentId.create(
                                     knownLeaderInformationComponent,
-                                    LeaderInformation.known(UUID.randomUUID(), "localhost"))));
+                                    LeaderInformation.known(leaderSessionID, "localhost"))));
 
             knownLeaderElectionEventHandler.unblock();
             unknownLeaderElectionEventHandler.unblock();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.leaderelection;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /** Leader election event. */
 public abstract class LeaderElectionEvent {
@@ -51,6 +52,17 @@ public abstract class LeaderElectionEvent {
     }
 
     public static class IsLeaderEvent extends LeaderElectionEvent {
+
+        private final UUID newLeaderSessionID;
+
+        public IsLeaderEvent(UUID newLeaderSessionID) {
+            this.newLeaderSessionID = newLeaderSessionID;
+        }
+
+        public UUID getLeaderSessionID() {
+            return newLeaderSessionID;
+        }
+
         @Override
         public boolean isIsLeaderEvent() {
             return true;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.ExceptionUtils;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -38,8 +39,8 @@ public final class TestingLeaderElectionListener
             new ArrayBlockingQueue<>(10);
 
     @Override
-    public void isLeader() {
-        put(new LeaderElectionEvent.IsLeaderEvent());
+    public void isLeader(UUID newLeaderSessionID) {
+        put(new LeaderElectionEvent.IsLeaderEvent(newLeaderSessionID));
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriver.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import java.util.Optional;
+import java.util.UUID;
 
 /** Testing implementation of {@link MultipleComponentLeaderElectionDriver}. */
 public class TestingMultipleComponentLeaderElectionDriver
@@ -45,10 +46,10 @@ public class TestingMultipleComponentLeaderElectionDriver
         listener = Optional.empty();
     }
 
-    public void grantLeadership() {
+    public void grantLeadership(UUID newLeaderSessionID) {
         if (!hasLeadership) {
             hasLeadership = true;
-            listener.ifPresent(Listener::isLeader);
+            listener.ifPresent(listener -> listener.isLeader(newLeaderSessionID));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
@@ -361,7 +361,7 @@ class ZooKeeperMultipleComponentLeaderElectionDriverTest {
             return leaderElectionDriver.hasLeadership();
         }
 
-        CompletableFuture<Void> getLeadershipFuture() {
+        CompletableFuture<UUID> getLeadershipFuture() {
             return leaderElectionListener.getLeadershipFuture();
         }
 
@@ -374,15 +374,15 @@ class ZooKeeperMultipleComponentLeaderElectionDriverTest {
     private static final class SimpleLeaderElectionListener
             implements MultipleComponentLeaderElectionDriver.Listener {
 
-        private final CompletableFuture<Void> leadershipFuture = new CompletableFuture<>();
+        private final CompletableFuture<UUID> leadershipFuture = new CompletableFuture<>();
 
-        CompletableFuture<Void> getLeadershipFuture() {
+        CompletableFuture<UUID> getLeadershipFuture() {
             return leadershipFuture;
         }
 
         @Override
-        public void isLeader() {
-            leadershipFuture.complete(null);
+        public void isLeader(UUID newLeaderSessionID) {
+            leadershipFuture.complete(newLeaderSessionID);
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

Makes `DefaultLeaderElectionService` implement `MultipleComponentLeaderElectionDriver.Listener` besides the `LeaderElectionEventHandler` interface.

## Brief change log

* Makes `DefaultLeaderElectionService` implement `MultipleComponentLeaderElectionDriver.Listener`
* Modifies `MultipleComponentLeaderElectionDriver.Listener` in a way that `isLeader` requires the session ID to be passed in instead of generating it internally. This aligns more with how `LeaderElectionEventHandler` was implemented. It also makes more sense because the HA backend should be the owner of the session ID: Theoretically, it could provide such a session ID.

## Verifying this change

* The test code is adapted in a way that it only uses the `MultipleComponentLeaderElectionDriver.Listener` methods.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable